### PR TITLE
corrections

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
 <!-- sidebar -->
 <div class="well col-md-3 col-md-offset-0">
-  <h5>A Guide to Cables and Connectors Used For Audiovisual Tech</h5>
+  <h5>A Guide to Cables and Connectors Used for Audiovisual Tech</h5>
   <p>A comprehensive source for identifying cables and connectors potentially used for audiovisual/media preservation. Cable types and connectors are organized by the primary purpose of the signal being transferred - video, audio-only, data (i.e. computer cables) and power. Examples of physical connectors (along with pinouts and contextual uses for each kind of cable/connector combination) are provided in buttons, nested within descriptions of signal types, wiring, interfaces and protocols!</p>
   <h5>License and Attribution</h5>
   <p><a href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"></a><br>This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a></p>
@@ -47,7 +47,7 @@
       <li><a href="#analog_video">Analog Video</a></li>
         <ol type="1">
         <li><a href="#composite">Composite</a></li>
-        <li><a href="#component_ypbpr">Component Y'P<sub>B</sub>P<sub>R</sub></a></li>
+        <li><a href="#component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></a></li>
         <li><a href="#s-video">S-Video</a></li>
         <li><a href="#rgbs">RGBS</a></li>
         <li><a href="#rgbvh">RGBVH</a></li>
@@ -133,7 +133,7 @@
             <img src="images/composite_RCA.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/c/cd/Composite-video-cable.jpg">
             <img src="images/Video/composite_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.doom9.org/capture/images/CompositeJack.jpeg">
           </div>
-          <p>Used primarily with consumer equipment (e.g. Betamax, VHS, DVD)</p>
+          <p>Used primarily with consumer equipment (e.g. Betamax, VHS, DVD).</p>
           <p>Audio: no</p>
         </div>
       </div>
@@ -152,7 +152,7 @@
             <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
             <img src="images/Video/composite_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/FME-Female-to-BNC-Female-Adaptor.jpg">
           </div>
-          <p>Used in professional broadcast and some consumer equipment</p>
+          <p>Used in professional broadcast and some consumer equipment.</p>
           <p>Audio: no</p>
         </div>
       </div>
@@ -171,7 +171,7 @@
           <img src="images/Video/composite_UHF_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/26/UHF-Connector.png/250px-UHF-Connector.png">
           <img src="images/Video/composite_uhf_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://ecx.images-amazon.com/images/I/41QIUVFJkbL.jpg">
         </div>
-        <p>A WWII-era connector design originally intended for video connections in radar applications. Used with late-period 1/2" open reel decks (e.g. Sony AV decks) and some early 3/4" U-matic players.</p>
+        <p>A WWII-era connector design originally intended for video connections in radar applications. Used with late-period 1/2″ open reel decks (e.g. Sony AV decks) and some early 3/4″ U-matic players.</p>
         <p>Audio: no</p>
       </div>
     </div>
@@ -190,7 +190,7 @@
           <img src="images/composite_F-type.jpg" data-toggle="tooltip" data-placement="bottom">
           <img src="images/Video/composite_f-type_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.cutcabletoday.com/wp-content/uploads/2015/03/coax-jack.jpg">
         </div>
-        <p> Found in North American television antenna, cable and satellite television installations; some older VCRs</p>
+        <p>Found in North American television antenna, cable and satellite television installations; some older VCRs.</p>
         <p>Audio: no</p>
       </div>
     </div>
@@ -228,7 +228,7 @@
           <img src="images/Video/composite_eiaj_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.markertek.com/productImage/HI-RES/E8M.JPG">
           <img src="images/Video/composite_eiaj_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.markertek.com/productImage/450X450/E8FCM.JPG">
         </div>
-        <p>Monitor cables designed specifically to carry both input and output signal between a video deck and monitor over the same cable. Seen on 1/2" open reel decks (the only available output on Sony CVs), 3/4" U-matic, and contemporary monitors.</p>
+        <p>Monitor cables designed specifically to carry both input and output signal between a video deck and monitor over the same cable. Seen on 1/2″ open reel decks (the only available output on Sony CVs), 3/4″ U-matic, and contemporary monitors.</p>
         <p>Audio: yes, stereo, unbalanced</p>
       </div>
     </div>
@@ -259,8 +259,8 @@
 
 
 <!-- start Component YPbPr cables -->
-  <div class="well"><h4 id="component_ypbpr">Component Y'P<sub>B</sub>P<sub>R</sub></h4>
-    <p>Y′P<sub>B</sub>P<sub>R</sub> signal is often referred to, imprecisely, simply as "component" video, although there are actually several standards of component video (any signal standard that splits video information into multiple channels is component, including S-Video and the multiple RGB standards). In Y′P<sub>B</sub>P<sub>R</sub>, the video signal is split into three channels: Y (containing luminance and sync), P<sub>B</sub> (the difference between blue and luma), and P<sub>R</sub> (the difference between red and luma). The remaining (green) chrominance information is derived from the relationship between these three signals. Y′P<sub>B</sub>P<sub>R</sub> cables are sometimes referred to as "yipper" cables and are connectors are usually color-coded (Y=green, P<sub>B</sub>=blue, P<sub>R</sub>=red); however Y′P<sub>B</sub>P<sub>R</sub> cables are fundamentally wired the same as composite cables and can be used interchangeably as long as the corresponding ports are properly connected.</p>
+  <div class="well"><h4 id="component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></h4>
+    <p>Y′P<sub>B</sub>P<sub>R</sub> signal is often referred to, imprecisely, simply as "component" video, although there are actually several standards of component video (any signal standard that splits video information into multiple channels is component, including S-Video and the multiple RGB standards). In Y′P<sub>B</sub>P<sub>R</sub>, the video signal is split into three channels: Y (containing luminance and sync), P<sub>B</sub> (the difference between blue and luma), and P<sub>R</sub> (the difference between red and luma). The remaining (green) chrominance information is derived from the relationship between these three signals. Y′P<sub>B</sub>P<sub>R</sub> cables are sometimes referred to as "yipper" cables and are connectors are usually color-coded (Y&nbsp;=&nbsp;green, P<sub>B</sub>&nbsp;=&nbsp;blue, P<sub>R</sub>&nbsp;=&nbsp;red); however Y′P<sub>B</sub>P<sub>R</sub> cables are fundamentally wired the same as composite cables and can be used interchangeably as long as the corresponding ports are properly connected.</p>
     <p><b>Introduced:</b>unknown</p>
     <p><b>Max resolution:</b> High Definition (up to 1080p)</p>
     <p><b>Connectors:</b></p>
@@ -271,12 +271,12 @@
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="well">
-      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rca">Component Y'P<sub>B</sub>P<sub>R</sub> RCA</a></h3>
+      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rca">Component Y′P<sub>B</sub>P<sub>R</sub> RCA</a></h3>
       <div class="sample-image">
         <img src="images/component_rca.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/1d/Component-cables.jpg">
         <img src="images/Video/component_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ef/Component_video_jack.jpg">
       </div>
-      <p>Used primarily with consumer equipment</p>
+      <p>Used primarily with consumer equipment.</p>
       <p>Audio: no</p>
     </div>
   </div>
@@ -290,12 +290,12 @@
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="well">
-      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">Component Y'P<sub>B</sub>P<sub>R</sub> BNC</a></h3>
+      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">Component Y′P<sub>B</sub>P<sub>R</sub> BNC</a></h3>
       <div class="sample-image">
         <img src="images/Video/component_bnc_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/Python-3-BNC-To-3-RCA-Component-Video-Cable-4.jpg">
         <img src="images/Video/component_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://salestores.com/stores/images/images_747/AVOV3HDF.jpg">
       </div>
-      <p>Seen with professional broadcast and production equipment, some consumer electronics</p>
+      <p>Seen with professional broadcast and production equipment, some consumer electronics.</p>
       <p>Audio: no</p>
     </div>
   </div>
@@ -885,17 +885,17 @@
 
       <!-- start Balanced Analog audio cables -->
       <div class="well"><h4 id="balanced_analog">Balanced Analog Audio</h4>
-        <p>Balanced coaxial audio cables contain three wires: "earth" (electrical ground), "hot" (positive audio signal), and "cold" (negative audio signal). The audio signal is transferred on both the hot and cold lines, but the voltage in the cold line is inverted (i.e. signal is negative when the hot line's is positive, and vice versa). When the cable is plugged into an input, the hot and cold signals are mixed together, but the cold signal is also inverted again. This has the effect of strengthening the original, recorded audio signal (doubling the number of wires it was carried on) while also canceling out the signal of any unintentional noise in the signal picked up as the audio traveled over the cable. (Since that noise was essentially "recorded" positively on to both the hot and cold lines, flipping the polarity of the cold line at input gives you exact opposite noise signals, which cancel each other out) </p>
+        <p>Balanced coaxial audio cables contain three wires: "earth" (electrical ground), "hot" (positive audio signal), and "cold" (negative audio signal). The audio signal is transferred on both the hot and cold lines, but the voltage in the cold line is inverted (i.e. signal is negative when the hot line's is positive, and vice versa). When the cable is plugged into an input, the hot and cold signals are mixed together, but the cold signal is also inverted again. This has the effect of strengthening the original, recorded audio signal (doubling the number of wires it was carried on) while also canceling out the signal of any unintentional noise in the signal picked up as the audio traveled over the cable. (Since that noise was essentially "recorded" positively on to both the hot and cold lines, flipping the polarity of the cold line at input gives you exact opposite noise signals, which cancel each other out.)</p>
         <p>Reducing analog audio noise is an issue primarily with longer cables, or in professional/broadcast or preservation environments, where the absolute integrity of the audio signal is more highly valued than on consumer equipment.</p>
         <p><b>Connectors:</b></p>
 
         <!-- Balanced 1/4" TRS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-4_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4" TRS jack (mono)</button></span>
+        <span data-toggle="modal" data-target="#1-4_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4″ TRS jack (mono)</button></span>
         <div id="1-4_trs_mono" class="modal fade" tabindex="-1" role="dialog">
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced 1/4" TRS Jack (mono)</a></h3>
+            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced 1/4″ TRS Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
             </div>
@@ -907,16 +907,16 @@
         <!-- end Balanced 1/4" TRS jack (mono) -->
 
         <!-- Balanced 1/8" TRS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-8_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8" TRS "mini" jack (mono)</button></span>
+        <span data-toggle="modal" data-target="#1-8_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TRS "mini" jack (mono)</button></span>
         <div id="1-8_trs_mono" class="modal fade" tabindex="-1" role="dialog">
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced 1/8" TRS "Mini" Jack (mono)</a></h3>
+            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced 1/8″ TRS "Mini" Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
             </div>
-            <p>Essentially the same in design as the 1/4" jack, just smaller. Used sometimes for balanced mono audio with computers or portable devices.</p>
+            <p>Essentially the same in design as the 1/4″ jack, just smaller. Used sometimes for balanced mono audio with computers or portable devices.</p>
           </div>
           </div>
           </div>
@@ -933,7 +933,7 @@
             <div class="sample-image">
               <img src="images/Audio/TT_bantam_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/43-183_01.jpg">
             </div>
-            <p>Tiny Telephone (TT, also sometimes called bantam) jacks are smaller than 1/4" but larger than 1/8" jacks (approx 4.40mm). Frequently employed with patch bays in professional audio recording and preservation environments. TT jacks are most commonly found with TRS design on balanced mono cables, but unbalanced or stereo versions are possible.</p>
+            <p>Tiny Telephone (TT, also sometimes called bantam) jacks are smaller than 1/4″ but larger than 1/8″ jacks (approx 4.40mm). Frequently employed with patch bays in professional audio recording and preservation environments. TT jacks are most commonly found with TRS design on balanced mono cables, but unbalanced or stereo versions are possible.</p>
           </div>
           </div>
           </div>
@@ -986,7 +986,7 @@
             <div class="sample-image">
               <img src="images/Audio/edac_elco_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/47-201_01.jpg">
             </div>
-            <p>Another brand of modular, adaptable connectors. Similar in appearance and use to Phoenix. Available in various configurations..</p>
+            <p>Another brand of modular, adaptable connectors. Similar in appearance and use to Phoenix. Available in various configurations.</p>
           </div>
           </div>
           </div>
@@ -997,7 +997,7 @@
 
       <!-- start Unbalanced Analog audio cables -->
       <div class="well"><h4 id="unbalanced_analog">Unbalanced Analog Audio</h4>
-        <p>nbalanced audio cables contain only two wires for any one audio channel: "earth" (electrical ground) and "hot" (the audio signal). These are employed with short cables, internal cables or components (inside sound equipment), or consumer-grade equipment where noise is considered less of an issue.</p>
+        <p>Unbalanced audio cables contain only two wires for any one audio channel: "earth" (electrical ground) and "hot" (the audio signal). These are employed with short cables, internal cables or components (inside sound equipment), or consumer-grade equipment where noise is considered less of an issue.</p>
         <p><b>Connectors:</b></p>
 
         <!-- Unbalanced RCA -->
@@ -1011,7 +1011,7 @@
               <img src="images/Audio/audio_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://resource.supercheats.com/library/300w/xbox-360/xbox-hdmi-audio7.jpg">
               <img src="images/Audio/audio_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn9.digitaltrends.com/image/nuforce-s3_bt-bluetooth-bookshelf-speakers-right-channel-rear-audio-input-macro-1500x991.jpg">
             </div>
-            <p>By nature unbalanced connectors as they only have one pin/contact point. Frequently used for the two-channel (left and right) audio output of video decks, especially consumer-grade equipment (in such cases, often color-coded white and red, where white = channel 1/left, red = channel 2, right).</p>
+            <p>By nature unbalanced connectors as they only have one pin/contact point. Frequently used for the two-channel (left and right) audio output of video decks, especially consumer-grade equipment (in such cases, often color-coded white and red, where white&nbsp;=&nbsp;channel&nbsp;1/left, red&nbsp;=&nbsp;channel 2/right).</p>
           </div>
           </div>
           </div>
@@ -1024,11 +1024,11 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-sleeve">Unbalanced 1/4" Tip-Sleeve Jack (mono)</a></h3>
+            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-sleeve">Unbalanced 1/4″ Tip-Sleeve Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:4-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/1-4-Mono-Plug-to-3-5mm-Mono-Jack-1.jpg">
             </div>
-            <p>TS (Tip/Sleeve) jacks are exactly the same in appearance as balanced 1/4" TRS jacks, except missing the "ring" contact point and cold wire. Often used for the output on musical instruments such as electric guitars.</p>
+            <p>TS (Tip/Sleeve) jacks are exactly the same in appearance as balanced 1/4″ TRS jacks, except missing the "ring" contact point and cold wire. Often used for the output on musical instruments such as electric guitars.</p>
           </div>
           </div>
           </div>
@@ -1036,16 +1036,16 @@
         <!-- end Unbalanced 1/4" TS jack (mono) -->
 
         <!-- Unbalanced 1/8" TS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-8_TS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8" TS jack</button></span>
+        <span data-toggle="modal" data-target="#1-8_TS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TS jack</button></span>
         <div id="1-8_TS_jack" class="modal fade" tabindex="-1" role="dialog">
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-sleeve">Unbalanced 1/8" Tip-Sleeve Jack (mono)</a></h3>
+            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-sleeve">Unbalanced 1/8″ Tip-Sleeve Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:8-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://images-na.ssl-images-amazon.com/images/G/01/musical-instruments/detail-page/B000068O47_img1.jpg">
             </div>
-            <p>Smaller version of the unbalanced 1/4" TS jack. Seen with [???]</p>
+            <p>Smaller version of the unbalanced 1/4″ TS jack. Seen with [???]</p>
           </div>
           </div>
           </div>
@@ -1053,16 +1053,16 @@
         <!-- end Unbalanced 1/8" TS jack (mono) -->
 
         <!-- Unbalanced 1/4" TRS jack (stereo) -->
-        <span data-toggle="modal" data-target="#unbalanced_1-4_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4" TRS jack (stereo)</button></span>
+        <span data-toggle="modal" data-target="#unbalanced_1-4_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4″ TRS jack (stereo)</button></span>
         <div id="unbalanced_1-4_TRS_jack" class="modal fade" tabindex="-1" role="dialog">
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Unbalanced 1/4" Tip-Ring-Sleeve Jack (stereo)</a></h3>
+            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Unbalanced 1/4″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
             </div>
-            <p>By all outward appearance, the same as the 1/4" TRS jacks used for balanced mono cables, except in the case of unbalanced stereo the three contact points are used for ground and two channels of audio, rather than ground and hot/cold versions of one audio channel. Often seen with professional headphones, and stereo microphone/monitor connections on professional video decks.</p>
+            <p>By all outward appearance, the same as the 1/4″ TRS jacks used for balanced mono cables, except in the case of unbalanced stereo the three contact points are used for ground and two channels of audio, rather than ground and hot/cold versions of one audio channel. Often seen with professional headphones, and stereo microphone/monitor connections on professional video decks.</p>
           </div>
           </div>
           </div>
@@ -1070,12 +1070,12 @@
         <!-- end Unbalanced 1/4" TRS jack (stereo) -->
 
         <!-- Unbalanced 1/8" TRS jack (stereo) -->
-        <span data-toggle="modal" data-target="#unbalanced_1-8_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8" TRS jack (stereo)</button></span>
+        <span data-toggle="modal" data-target="#unbalanced_1-8_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TRS jack (stereo)</button></span>
         <div id="unbalanced_1-8_TRS_jack" class="modal fade" tabindex="-1" role="dialog">
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Unbalanced 1/8" Tip-Ring-Sleeve Jack (stereo)</a></h3>
+            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Unbalanced 1/8″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
             </div>
@@ -1114,7 +1114,7 @@
 
       <!-- start AES-3 protocol cables -->
       <div class="well"><h4 id="aes-3">AES-3</h4>
-          <p>AES-3 is a standard for the exchange of digital audio signals developed in conjunction by the Audio Engineering Society and the European Broadcasting Union, and is therefore also often referred to as "AES-EBU." AES-3 is capable of carrying two uncompressed channels of uncompressed PCM audio, or compressed 5.1/7.1 surround sound over the same cable.</p>
+          <p>AES-3 is a standard for the exchange of digital audio signals developed in conjunction by the Audio Engineering Society and the European Broadcasting Union, and is therefore also often referred to as "AES-EBU". AES-3 is capable of carrying two uncompressed channels of uncompressed PCM audio, or compressed 5.1/7.1 surround sound over the same cable.</p>
           <p><b>Introduced: </b>1985</p>
           <p><b>Max resolution:</b> 24-bit</p>
           <p><b>Wiring and Connectors:</b></p>
@@ -1203,7 +1203,7 @@
                   <img src="images/Audio/spdif_mini-toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://images.monoprice.com/productlargeimages/26711.jpg">
                   <img src="images/Audio/spdif_mini-toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.headfonia.com/wp-content/uploads/2010/05/drdac_prime_10.jpg">
                 </div>
-                <p>A smaller version of the TOSLINK connector that is almost the same size and shape of a 1/8" TRS stereo jack. Some combined 1/8" stereo jack and Mini TOSLINK ports exist to accept either digital or analog audio input/output. Mini TOSLINK is generally used with smaller consumer-grade digital audio equipment (e.g. portable CD players).</p>
+                <p>A smaller version of the TOSLINK connector that is almost the same size and shape of a 1/8″ TRS stereo jack. Some combined 1/8″ stereo jack and Mini TOSLINK ports exist to accept either digital or analog audio input/output. Mini TOSLINK is generally used with smaller consumer-grade digital audio equipment (e.g. portable CD players).</p>
               </div>
               </div>
               </div>
@@ -1490,7 +1490,7 @@
 
       <!-- start RS-232 protocol cables -->
       <div class="well"><h4 id="rs-232">RS-232</h4>
-        <p>Because it was the first serial data protocol to become a standard feature in personal computing, RS-232 was commonly referred to simply as "the serial port." It was used for bidirectional connection to many peripheral computer devices, including modems, printers, mice, external drives, etc. It was also used for remote connection and control of some VTRs. It is referred to as "RS" because it was originally sponsored by the Radio Sector of the Electronic Industries Association - changes in the sponsoring organization have caused the standard to be alternately referred to as EIA-232 and TIA-232. The symbol below generally marked serial port connections on computers.</p>
+        <p>Because it was the first serial data protocol to become a standard feature in personal computing, RS-232 was commonly referred to simply as "the serial port". It was used for bidirectional connection to many peripheral computer devices, including modems, printers, mice, external drives, etc. It was also used for remote connection and control of some VTRs. It is referred to as "RS" because it was originally sponsored by the Radio Sector of the Electronic Industries Association - changes in the sponsoring organization have caused the standard to be alternately referred to as EIA-232 and TIA-232. The symbol below generally marked serial port connections on computers.</p>
         <img src="images/Data/serial_port_logo.png" data-toggle="tooltip" data-placement="bottom" title="http://cliparts.co/cliparts/Big/E86/BigE86ErT.png" style="background-color:white; max-height:100px;">
         <p><b>Introduced: </b>1962</p>
         <p><b>Max bit depth and rate: </b></p>
@@ -1719,7 +1719,7 @@
 
       <!-- start USB protocol cables -->
       <div class="well"><h4 id="usb">USB</h4>
-        <p>Short for Universal Serial Bus, designed to standardize connections of computer peripherals after the proliferation of connections in the '80s and early '90s. Used with keyboards, mice, digital cameras, external drives, network adapters, etc. Capable of supplying power to many of these devices in addition to transmitting data. Updates to the original USB 1.0 standard (1.5 Mbit/s at Low Speed, 12 Mbit/s at Full Speed) have represented major shifts in data transmission, usually with accompanied changes in physical connection, so they are elaborated on more below. All advancements in USB have been backwards-compatible (so a USB 3.0 connection can carry USB 2.0 data, etc). Ports are also usually marked by the symbol below.</p>
+        <p>Short for Universal Serial Bus, designed to standardize connections of computer peripherals after the proliferation of connections in the 1980s and early 1990s. Used with keyboards, mice, digital cameras, external drives, network adapters, etc. Capable of supplying power to many of these devices in addition to transmitting data. Updates to the original USB 1.0 standard (1.5 Mbit/s at Low Speed, 12 Mbit/s at Full Speed) have represented major shifts in data transmission, usually with accompanied changes in physical connection, so they are elaborated on more below. All advancements in USB have been backwards-compatible (so a USB 3.0 connection can carry USB 2.0 data, etc). Ports are also usually marked by the symbol below.</p>
         <img src="images/Data/usb_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fd/USB_Icon.svg/2000px-USB_Icon.svg.png" style="background-color:white; max-height:100px;">
         <p><b>Introduced: </b>1996</p>
 
@@ -1886,7 +1886,7 @@
                 <img src="images/Data/USB3_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/usb_3_b.jpg">
                 <img src="images/Data/USB3_typeB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://hsto.org/getpro/habr/post_images/c40/af2/062/c40af20620352d5a35b1cadb413bc739.jpg">
               </div>
-              <p>A boxy connection similar in appearance to USB 2.0 Type B, but not physically compatible with its preceding equivalent (unlike Type A). Therefore cables with a USB 3.0 Type B connector are not compatible with devices with a USB 2.0 Type B port; however devices with a USB 3.0 Type B port *will* accept USB 2.0 Type B cables. Usually colored blue.</p>
+              <p>A boxy connection similar in appearance to USB 2.0 Type B, but not physically compatible with its preceding equivalent (unlike Type A). Therefore cables with a USB 3.0 Type B connector are not compatible with devices with a USB 2.0 Type B port; however devices with a USB 3.0 Type B port <b>will</b> accept USB 2.0 Type B cables. Usually colored blue.</p>
             </div>
             </div>
             </div>
@@ -2116,7 +2116,7 @@
 
   <!-- start Power cables -->
   <div class="well"><h2 id="power"><u>Power</u></h2>
-    <p> From Type A to Type N, the <a href="http://www.iec.ch/worldplugs/">IEC website</a> provides descriptions, images, and supporting countries to plugs and sockets used around the world.</p>
+    <p>From Type A to Type N, the <a href="http://www.iec.ch/worldplugs/" target="_blank">IEC website</a> provides descriptions, images, and supporting countries to plugs and sockets used around the world.</p>
 
   </div> <!-- end Power well -->
 

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
         <li><a href="#ps2">PS/2</a></li>
         <li><a href="#usb">USB</a></li>
         <li><a href="#firewire_data">FireWire</a></li>
-        <li><a href="#thunderbolt">ThunderBolt</a></li>
+        <li><a href="#thunderbolt">Thunderbolt</a></li>
         <li><a href="#hdbaset">HDBaseT</a></li>
         </ol></li>
       </ol></li>
@@ -1947,7 +1947,7 @@
 
       <!-- start FireWire protocol cables -->
       <div class="well"><h4 id="firewire_data">FireWire</h4>
-        <p>Developed by Apple at roughly the same time as USB, for the similar purpose of consolidating connections and improving data transfer speeds. Unlike USB, FireWire does not require the use of a host controller (FireWire-compatible devices can communicate directly to each other without the use of a computer), but it was more costly to implement than USB and therefore never quite as popular. Sometimes referred to as i.Link (in Sony applications) and Lynx (Texas Instruments), as FireWire is technically just the Apple branding of the IEEE 1394 standard. Used for connections to external hard drives, as well as A/V component communication and control. Two major flavors of FireWire were introduced before Apple phased out development of the standard in favor of ThunderBolt. Ports usually represented by the symbol below.</p>
+        <p>Developed by Apple at roughly the same time as USB, for the similar purpose of consolidating connections and improving data transfer speeds. Unlike USB, FireWire does not require the use of a host controller (FireWire-compatible devices can communicate directly to each other without the use of a computer), but it was more costly to implement than USB and therefore never quite as popular. Sometimes referred to as i.Link (in Sony applications) and Lynx (Texas Instruments), as FireWire is technically just the Apple branding of the IEEE 1394 standard. Used for connections to external hard drives, as well as A/V component communication and control. Two major flavors of FireWire were introduced before Apple phased out development of the standard in favor of Thunderbolt. Ports usually represented by the symbol below.</p>
         <img src="images/Data/firewire_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/FireWire_Logo.svg/2000px-FireWire_Logo.svg.png" style="background-color:white; max-height:100px;">
 
         <!-- start FireWire 400 cables -->
@@ -2025,65 +2025,65 @@
       </div> <!-- end FireWire well -->
 
 
-      <!-- start ThunderBolt protocol cables -->
-      <div class="well"><h4 id="thunderbolt">ThunderBolt</h4>
-        <p>Developed by Apple as a replacement for FireWire. Combines computer bus data transmission with the DisplayPort digital video interface, as well as DC power, all over one cable/connection. The first two major versions of ThunderBolt shared a physical connector and had compatible wiring/channels, but the introduction of ThunderBolt 3 has been marked by major shifts in physical interface. Ports usually labelled by the symbol below.</p>
+      <!-- start Thunderbolt protocol cables -->
+      <div class="well"><h4 id="thunderbolt">Thunderbolt</h4>
+        <p>Developed by Apple as a replacement for FireWire. Combines computer bus data transmission with the DisplayPort digital video interface, as well as DC power, all over one cable/connection. The first two major versions of Thunderbolt shared a physical connector and had compatible wiring/channels, but the introduction of Thunderbolt 3 has been marked by major shifts in physical interface. Ports usually labelled by the symbol below.</p>
         <img src="images/Data/thunderbolt_logo.jpg" data-toggle="tooltip" data-placement="bottom" title="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/thunderbolt_logo.png" style="max-height:100px;">
 
-        <!-- start ThunderBolt 1 and 2 cables -->
-        <div class="well"><h5>ThunderBolt 1 and 2</h5>
+        <!-- start Thunderbolt 1 and 2 cables -->
+        <div class="well"><h5>Thunderbolt 1 and 2</h5>
           <p><b>Introduced: </b>2011;2013</p>
           <p><b>Max bit depth and rate: </b>10 Gb/s; 20 Gb/s</p>
           <p><b>Connectors and ports:</b></p>
 
-          <!-- ThunderBolt 1 and 2 Mini-DisplayPort -->
+          <!-- Thunderbolt 1 and 2 Mini-DisplayPort -->
           <span data-toggle="modal" data-target="#thunderbolt_mini-displayport"><button type="button" class="btn btn-default"><img src="images/Data/thunderbolt_mini-displayport_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DisplayPort</button></span>
           <div id="thunderbolt_mini-displayport" class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#displayport">ThunderBolt 1 and 2 Mini-DisplayPort</a></h3>
+              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#displayport">Thunderbolt 1 and 2 Mini-DisplayPort</a></h3>
               <div class="sample-image">
                 <img src="images/Data/thunderbolt_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/TBOLTMMXMW.D.jpg">
                 <img src="images/Data/thunderbolt_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://support.seagate.com/kbimg/004528-1.jpg">
               </div>
-              <p>The ThunderBolt protocol was designed to be compatible with the Mini-DisplayPort connections already present since 2008 on many Apple computers. Saved Apple from a major redesign for several years.</p>
+              <p>The Thunderbolt protocol was designed to be compatible with the Mini-DisplayPort connections already present since 2008 on many Apple computers. Saved Apple from a major redesign for several years.</p>
             </div>
             </div>
             </div>
           </div>
-          <!-- end ThunderBolt 1 and 2 Mini-DisplayPort -->
+          <!-- end Thunderbolt 1 and 2 Mini-DisplayPort -->
 
-        </div> <!-- end ThunderBolt 1 and 2 -->
+        </div> <!-- end Thunderbolt 1 and 2 -->
 
 
-        <!-- start ThunderBolt 3 cables -->
-        <div class="well"><h5>ThunderBolt 3</h5>
+        <!-- start Thunderbolt 3 cables -->
+        <div class="well"><h5>Thunderbolt 3</h5>
           <p><b>Introduced: </b>2015</p>
           <p><b>Max bit depth and rate: </b>40 Gb/s</p>
           <p><b>Connectors and ports:</b></p>
 
-          <!-- ThunderBolt 3 USB Type C -->
+          <!-- Thunderbolt 3 USB Type C -->
           <span data-toggle="modal" data-target="#thunderbolt3_usb_type-c"><button type="button" class="btn btn-default"><img src="images/Data/thunderbolt_typeC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">USB Type C</button></span>
           <div id="thunderbolt3_usb_type-c" class="modal fade" tabindex="-1" role="dialog">
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-31">ThunderBolt 3 USB Type C</a></h3>
+              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-31">Thunderbolt 3 USB Type C</a></h3>
               <div class="sample-image">
                 <img src="images/Data/thunderbolt_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.flatpanelshd.com/pictures/thunderbolt3-1l.jpg">
                 <img src="images/Data/thunderbolt_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blogs.intel.com/technology/files/2015/08/Lenovo-ports.jpg">
               </div>
-              <p>Because of its capability for transferring data, digital video/audio and power all over the same connection, Apple adapted the USB Type C connector to its ThunderBolt protocol and has started using the connection as the single port on its latest MacBook Air products.</p>
+              <p>Because of its capability for transferring data, digital video/audio and power all over the same connection, Apple adapted the USB Type C connector to its Thunderbolt protocol and has started using the connection as the single port on its latest MacBook Air products.</p>
             </div>
             </div>
             </div>
           </div>
-          <!-- end ThunderBolt 3 USB Type C -->
+          <!-- end Thunderbolt 3 USB Type C -->
 
-        </div> <!-- end ThunderBolt 3 -->
+        </div> <!-- end Thunderbolt 3 -->
 
-      </div> <!-- end ThunderBolt well -->
+      </div> <!-- end Thunderbolt well -->
 
 
       <!-- start HDBaseT protocol cables -->

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rca">Composite RCA</a></h3>
+          <h3><a href="pinouts.md#rca">Composite RCA</a></h3>
           <div class="sample-image">
             <img src="images/composite_RCA.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/c/cd/Composite-video-cable.jpg">
             <img src="images/Video/composite_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.doom9.org/capture/images/CompositeJack.jpeg">
@@ -147,7 +147,7 @@
     <div class="modal-dialog modal-lg">
       <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">Composite BNC</a></h3>
+          <h3><a href="pinouts.md#bnc">Composite BNC</a></h3>
           <div class="sample-image">
             <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
             <img src="images/Video/composite_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/FME-Female-to-BNC-Female-Adaptor.jpg">
@@ -223,7 +223,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#8-pin-eiaj">Composite 8-pin EIAJ</a></h3>
+        <h3><a href="pinouts.md#8-pin-eiaj">Composite 8-pin EIAJ</a></h3>
         <div class="sample-image">
           <img src="images/Video/composite_eiaj_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.markertek.com/productImage/HI-RES/E8M.JPG">
           <img src="images/Video/composite_eiaj_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.markertek.com/productImage/450X450/E8FCM.JPG">
@@ -242,7 +242,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#scart">Composite SCART</a></h3>
+        <h3><a href="pinouts.md#scart">Composite SCART</a></h3>
         <div class="sample-image">
           <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
           <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
@@ -271,7 +271,7 @@
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="well">
-      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rca">Component Y′P<sub>B</sub>P<sub>R</sub> RCA</a></h3>
+      <h3><a href="pinouts.md#rca">Component Y′P<sub>B</sub>P<sub>R</sub> RCA</a></h3>
       <div class="sample-image">
         <img src="images/component_rca.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/1d/Component-cables.jpg">
         <img src="images/Video/component_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ef/Component_video_jack.jpg">
@@ -290,7 +290,7 @@
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="well">
-      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">Component Y′P<sub>B</sub>P<sub>R</sub> BNC</a></h3>
+      <h3><a href="pinouts.md#bnc">Component Y′P<sub>B</sub>P<sub>R</sub> BNC</a></h3>
       <div class="sample-image">
         <img src="images/Video/component_bnc_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/Python-3-BNC-To-3-RCA-Component-Video-Cable-4.jpg">
         <img src="images/Video/component_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://salestores.com/stores/images/images_747/AVOV3HDF.jpg">
@@ -309,7 +309,7 @@
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="well">
-      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#scart">Component Y′P<sub>B</sub>P<sub>R</sub> SCART</a></h3>
+      <h3><a href="pinouts.md#scart">Component Y′P<sub>B</sub>P<sub>R</sub> SCART</a></h3>
       <div class="sample-image">
         <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
         <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
@@ -338,7 +338,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#s-video">S-Video Mini-DIN 4-pin</a></h3>
+        <h3><a href="pinouts.md#s-video">S-Video Mini-DIN 4-pin</a></h3>
         <div class="sample-image">
           <img src="images/S-video.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/S-video-connection.jpg/120px-S-video-connection.jpg">
           <img src="images/Video/s-video_mini-din-4_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://sewelldirect.com/images/connectors/photos/S-Video.jpg">
@@ -357,7 +357,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">S-Video BNC</a></h3>
+        <h3><a href="pinouts.md#bnc">S-Video BNC</a></h3>
         <div class="sample-image">
           <img src="images/Video/s-video_bnc_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.comprehensiveco.com/resize/shared/images/products/comprehensive/s4pyc6hr.jpg?lr=t&bw=1000&w=1000&bh=1000&h=1000">
         </div>
@@ -375,7 +375,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
-        <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#mini-din-4-pin">S-Video SCART</a></h3>
+        <h3><a href="pinouts.md#mini-din-4-pin">S-Video SCART</a></h3>
         <div class="sample-image">
           <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
           <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
@@ -403,7 +403,7 @@
         <div class="modal-dialog modal-lg">
           <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#scart">RGBS SCART</a></h3>
+              <h3><a href="pinouts.md#scart">RGBS SCART</a></h3>
               <div class="sample-image">
                 <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
                 <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
@@ -431,7 +431,7 @@
               <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                   <div class="well">
-                    <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#vga">RGBVH VGA (DE-15)</a></h3>
+                    <h3><a href="pinouts.md#vga">RGBVH VGA (DE-15)</a></h3>
                     <div class="sample-image">
                       <img src="images/Video/VGA_D-sub15_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Male_VGA_connector.jpg/170px-Male_VGA_connector.jpg">
                       <img src="images/Video/vga_d-sub15_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Male_VGA_connector.jpg/170px-Male_VGA_connector.jpg">
@@ -450,7 +450,7 @@
               <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                   <div class="well">
-                    <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#mini-vga">RGBVH Mini-VGA</a></h3>
+                    <h3><a href="pinouts.md#mini-vga">RGBVH Mini-VGA</a></h3>
                     <div class="sample-image">
                       <img src="images/VGA-mini.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/5/57/Mini-VGA-Connector.jpg">
                       <img src="images/Video/vga_mini-vga_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Mini-VGA_cropped.jpg/250px-Mini-VGA_cropped.jpg">
@@ -469,7 +469,7 @@
               <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                   <div class="well">
-                    <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">RGBVH BNC</a></h3>
+                    <h3><a href="pinouts.md#bnc">RGBVH BNC</a></h3>
                     <div class="sample-image">
                       <img src="images/Video/RGBVH_BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/83/BNC_connectors.jpg">
                     </div>
@@ -487,7 +487,7 @@
               <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                   <div class="well">
-                    <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#dvi">RGBVH DVI-A</a></h3>
+                    <h3><a href="pinouts.md#dvi">RGBVH DVI-A</a></h3>
                     <div class="sample-image">
                       <img src="images/Video/dvi-a_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://rubimages-liberty.netdna-ssl.com/hi-res/E-DVI_A-5BNCM_DVIend.png">
                       <img src="images/Video/dvi-a_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.bhs4.com/07/A/07A6C8140CC3555552F53D6859963A86DC347FE2_large.jpg">
@@ -506,7 +506,7 @@
               <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                   <div class="well">
-                    <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#mini-dvi">RGBVH Mini-DVI</a></h3>
+                    <h3><a href="pinouts.md#mini-dvi">RGBVH Mini-DVI</a></h3>
                     <div class="sample-image">
                       <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
                       <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
@@ -540,7 +540,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">SDI BNC</a></h3>
+            <h3><a href="pinouts.md#bnc">SDI BNC</a></h3>
             <div class="sample-image">
               <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
               <img src="images/Video/sdi_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.crestron.com/content/publicdownloads/products/a/a-dmc-sdi.png">
@@ -587,7 +587,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#4-pin">FireWire 4-pin</a></h3>
+            <h3><a href="pinouts.md#4-pin">FireWire 4-pin</a></h3>
             <div class="sample-image">
               <img src="images/firewire_4-pin.jpg" data-toggle="tooltip" data-placement="bottom" title="https://static.gearslutz.com/board/imgext.php?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fc%2Fca%2FFirewire4-pin.jpg&h=d489e11c664e0701ef5ff2c3bc40ca7e">
               <img src="images/Video/firewire_4-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://forum.notebookreview.com/attachments/firewire1-jpg.6106/">
@@ -616,7 +616,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#dvi">DVI-D Single-Link</a></h3>
+            <h3><a href="pinouts.md#dvi">DVI-D Single-Link</a></h3>
             <div class="sample-image">
               <img src="images/Video/dvi-d_single-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/DVIDSMMX.C.jpg">
             </div>
@@ -634,7 +634,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#dvi">DVI-D Dual-Link</a></h3>
+            <h3><a href="pinouts.md#dvi">DVI-D Dual-Link</a></h3>
             <div class="sample-image">
               <img src="images/Video/dvi-d_dual-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/DVIDDMMTA6.C.jpg">
               <img src="images/Video/dvi-d_dual-link_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.nikoslab.com/wp-content/uploads/2014/11/dvi_d_dual_port.jpg">
@@ -653,7 +653,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#mini-dvi">DVI-D Mini-DVI</a></h3>
+            <h3><a href="pinouts.md#mini-dvi">DVI-D Mini-DVI</a></h3>
             <div class="sample-image">
               <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
               <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
@@ -701,7 +701,7 @@
         <div class="modal-dialog modal-lg">
         <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#displayport">DisplayPort 20-pin (Full)</a></h3>
+          <h3><a href="pinouts.md#displayport">DisplayPort 20-pin (Full)</a></h3>
           <div class="sample-image">
             <img src="images/Video/displayport_20-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/a/a6/Displayport-cable.jpg">
             <img src="images/Video/displayport_20-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://farm4.static.flickr.com/3642/3534308094_79c94bd454.jpg">
@@ -720,7 +720,7 @@
         <div class="modal-dialog modal-lg">
         <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#displayport">Mini-DisplayPort</a></h3>
+          <h3><a href="pinouts.md#displayport">Mini-DisplayPort</a></h3>
           <div class="sample-image">
             <img src="images/Video/displayport_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ea/Mini_displayport.jpg">
             <img src="images/Video/displayport_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/47/Mini_DisplayPort_on_Apple_MacBook.jpg">
@@ -749,7 +749,7 @@
         <div class="modal-dialog modal-lg">
         <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#hdmi">HDMI Type A</a></h3>
+          <h3><a href="pinouts.md#hdmi">HDMI Type A</a></h3>
           <div class="sample-image">
             <img src="images/Video/hdmi_full_A_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://classrooms.berkeley.edu/sites/default/files/images/hdmi_full.jpeg">
             <img src="images/Video/hdmi_full_A_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.eos.ncsu.edu/e115/text/io_images/hdmi.jpg">
@@ -768,7 +768,7 @@
         <div class="modal-dialog modal-lg">
         <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#hdmi">HDMI Type C (Mini)</a></h3>
+          <h3><a href="pinouts.md#hdmi">HDMI Type C (Mini)</a></h3>
           <div class="sample-image">
             <img src="images/Video/hdmi_mini_C_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://4.bp.blogspot.com/_-4V2pG048aQ/TETWXYtMcbI/AAAAAAAAA3o/NXf3avRXGjA/s1600/HDMI-MINI-HDMI-MICRO-HDMI.jpg">
             <img src="images/Video/hdmi_mini_C_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cable-trader.co.uk/images/finder/mini-hdmi-port.jpg">
@@ -787,7 +787,7 @@
         <div class="modal-dialog modal-lg">
         <div class="modal-content">
         <div class="well">
-          <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#hdmi">HDMI Type D (Micro)</a></h3>
+          <h3><a href="pinouts.md#hdmi">HDMI Type D (Micro)</a></h3>
           <div class="sample-image">
             <img src="images/Video/hdmi_mini_C_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://4.bp.blogspot.com/_-4V2pG048aQ/TETWXYtMcbI/AAAAAAAAA3o/NXf3avRXGjA/s1600/HDMI-MINI-HDMI-MICRO-HDMI.jpg">
             <img src="images/Video/hdmi_micro_D_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cnet2.cbsistatic.com/hub/i/2011/05/09/e8365dde-fdc7-11e2-8c7c-d4ae52e62bcc/4e7eb083d9859813fa3d698b38bfc09b/Android-HDMI-Phone-port.jpg">
@@ -819,7 +819,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#dvi">DVI-I Single-Link</a></h3>
+            <h3><a href="pinouts.md#dvi">DVI-I Single-Link</a></h3>
             <div class="sample-image">
               <img src="images/Video/dvi-i_single-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.yourcablestore.com/assets/images/guides/plug_dvi-i_single.gif">
             </div>
@@ -837,7 +837,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#dvi">DVI-I Dual-Link</a></h3>
+            <h3><a href="pinouts.md#dvi">DVI-I Dual-Link</a></h3>
             <div class="sample-image">
               <img src="images/Video/dvi-i_dual-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.cablemagic.com.au/media/catalog/product/cache/1/image/5e06319eda06f020e43594a9c230972d/d/v/dviidual352_1.jpg">
               <img src="images/Video/dvi-i_dual-link_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/2904-4.jpg">
@@ -856,7 +856,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#mini-dvi">DVI-I Mini-DVI</a></h3>
+            <h3><a href="pinouts.md#mini-dvi">DVI-I Mini-DVI</a></h3>
             <div class="sample-image">
               <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
               <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
@@ -895,7 +895,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced 1/4″ TRS Jack (mono)</a></h3>
+            <h3><a href="pinouts.md#tip-ring-sleeve">Balanced 1/4″ TRS Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
             </div>
@@ -912,7 +912,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced 1/8″ TRS "Mini" Jack (mono)</a></h3>
+            <h3><a href="pinouts.md#tip-ring-sleeve">Balanced 1/8″ TRS "Mini" Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
             </div>
@@ -929,7 +929,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Balanced Tiny Telephone (TT)/Bantam Jack</a></h3>
+            <h3><a href="pinouts.md#tip-ring-sleeve">Balanced Tiny Telephone (TT)/Bantam Jack</a></h3>
             <div class="sample-image">
               <img src="images/Audio/TT_bantam_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/43-183_01.jpg">
             </div>
@@ -946,7 +946,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#xlr">Balanced XLR</a></h3>
+            <h3><a href="pinouts.md#xlr">Balanced XLR</a></h3>
             <div class="sample-image">
               <img src="images/Audio/xlr_cork_bottle_cable.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/15/Xlr-connectors.jpg">
               <img src="images/Audio/xlr_cork_port.jpg" data-toggle="tooltip" data-placement="bottom" title="http://jp.music-group.com/TCE/CR/StudioKonnekt48/images/main_out_xlr_large.jpg">
@@ -1006,7 +1006,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rca">Unbalanced RCA</a></h3>
+            <h3><a href="pinouts.md#rca">Unbalanced RCA</a></h3>
             <div class="sample-image">
               <img src="images/Audio/audio_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://resource.supercheats.com/library/300w/xbox-360/xbox-hdmi-audio7.jpg">
               <img src="images/Audio/audio_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn9.digitaltrends.com/image/nuforce-s3_bt-bluetooth-bookshelf-speakers-right-channel-rear-audio-input-macro-1500x991.jpg">
@@ -1024,7 +1024,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-sleeve">Unbalanced 1/4″ Tip-Sleeve Jack (mono)</a></h3>
+            <h3><a href="pinouts.md#tip-sleeve">Unbalanced 1/4″ Tip-Sleeve Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:4-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/1-4-Mono-Plug-to-3-5mm-Mono-Jack-1.jpg">
             </div>
@@ -1041,7 +1041,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-sleeve">Unbalanced 1/8″ Tip-Sleeve Jack (mono)</a></h3>
+            <h3><a href="pinouts.md#tip-sleeve">Unbalanced 1/8″ Tip-Sleeve Jack (mono)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:8-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://images-na.ssl-images-amazon.com/images/G/01/musical-instruments/detail-page/B000068O47_img1.jpg">
             </div>
@@ -1058,7 +1058,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Unbalanced 1/4″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
+            <h3><a href="pinouts.md#tip-ring-sleeve">Unbalanced 1/4″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
             </div>
@@ -1075,7 +1075,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#tip-ring-sleeve">Unbalanced 1/8″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
+            <h3><a href="pinouts.md#tip-ring-sleeve">Unbalanced 1/8″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
             <div class="sample-image">
               <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
             </div>
@@ -1092,7 +1092,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#din-5-pin">Unbalanced DIN 5-pin</a></h3>
+            <h3><a href="pinouts.md#din-5-pin">Unbalanced DIN 5-pin</a></h3>
             <div class="sample-image">
               <img src="images/Audio/audio_din-5-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.c2g.com/uk/static/content/images/resources/connector-guides/450/107_5_pin_din_at_m_iso.jpg">
               <img src="images/Audio/audio_din-5-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://connector.pinoutsguide.com/photo/din5df.jpg">
@@ -1127,7 +1127,7 @@
               <div class="modal-dialog modal-lg">
               <div class="modal-content">
               <div class="well">
-                <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#xlr">AES-3 XLR</a></h3>
+                <h3><a href="pinouts.md#xlr">AES-3 XLR</a></h3>
                 <div class="sample-image">
                   <img src="images/Audio/xlr_cork_bottle_cable.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/15/Xlr-connectors.jpg">
                 </div>
@@ -1148,7 +1148,7 @@
               <div class="modal-dialog modal-lg">
               <div class="modal-content">
               <div class="well">
-                <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#bnc">AES-3 BNC</a></h3>
+                <h3><a href="pinouts.md#bnc">AES-3 BNC</a></h3>
                 <div class="sample-image">
                   <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
                 </div>
@@ -1220,7 +1220,7 @@
               <div class="modal-dialog modal-lg">
               <div class="modal-content">
               <div class="well">
-                <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rca">S/PDIF RCA</a></h3>
+                <h3><a href="pinouts.md#rca">S/PDIF RCA</a></h3>
                 <div class="sample-image">
                   <img src="images/Audio/spdif_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.cablesnmore.com/content/images/thumbs/0004559_spdif-digital-rca_450.jpeg">
                   <img src="images/Audio/spdif_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.homestudiocorner.com/wp-content/uploads/2011/01/SPDIF.jpg">
@@ -1402,7 +1402,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#parallel-scsi">Parallel SCSI DB-25</a></h3>
+            <h3><a href="pinouts.md#parallel-scsi">Parallel SCSI DB-25</a></h3>
             <div class="sample-image">
               <img src="images/Data/scsi_25-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/SCSI_DB25.jpg">
               <img src="images/Data/scsi_25-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.cs.uaf.edu/users/olawlor/public_html/ref/mac_ports/scsi_db25.jpg">
@@ -1449,7 +1449,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#parallelprinter-port">Parallel Port DB-25</a></h3>
+            <h3><a href="pinouts.md#parallelprinter-port">Parallel Port DB-25</a></h3>
             <div class="sample-image">
               <img src="images/Data/parallel_port_25-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.alibaba.com/img/pb/487/415/275/275415487_248.jpg">
               <img src="images/Data/parallel_port_25-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn.computerhope.com/parallel-port.jpg">
@@ -1516,7 +1516,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#db-15">RS-232 DB-15</a></h3>
+            <h3><a href="pinouts.md#db-15">RS-232 DB-15</a></h3>
             <p>Found with RS-232 connections on some modems (on the modem end).</p>
           </div>
           </div>
@@ -1544,7 +1544,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#rs-232">RS-232 DE-9</a></h3>
+            <h3><a href="pinouts.md#rs-232">RS-232 DE-9</a></h3>
             <p>Found with RS-232 connections on early mice and keyboards.</p>
           </div>
           </div>
@@ -1568,7 +1568,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#sony-9-pin-rs-422-vtr-protocol">RS-422 DE-9</a></h3>
+            <h3><a href="pinouts.md#sony-9-pin-rs-422-vtr-protocol">RS-422 DE-9</a></h3>
             <p>Found on later VTRs, especially Sony models.</p>
           </div>
           </div>
@@ -1582,7 +1582,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#apple-rs-422">RS-422 Mini-DIN 8-pin</a></h3>
+            <h3><a href="pinouts.md#apple-rs-422">RS-422 Mini-DIN 8-pin</a></h3>
             <p>An RS-232 compatible variant of RS-422 widely used on Macintosh hardware.</p>
           </div>
           </div>
@@ -1644,7 +1644,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#esata">eSATA</a></h3>
+            <h3><a href="pinouts.md#esata">eSATA</a></h3>
             <div class="sample-image">
               <img src="images/Data/e-sata_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/USB3S2ESATA3.C.jpg">
               <img src="images/Data/e-sata_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.thecomputercoach.net/assets/images/eSATA_port.jpg">
@@ -1673,7 +1673,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#apple-desktop-bus">ADB Mini-DIN 4-pin</a></h3>
+            <h3><a href="pinouts.md#apple-desktop-bus">ADB Mini-DIN 4-pin</a></h3>
             <div class="sample-image">
               <img src="images/Data/apple_desktop_bus_cork.jpg">
               <img src="images/Data/apple_desktop_bus_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://ttic.uchicago.edu/~cotter/projects/aek2/images/adb.jpg">
@@ -1701,7 +1701,7 @@
           <div class="modal-dialog modal-lg">
           <div class="modal-content">
           <div class="well">
-            <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#ps2">PS/2 Mini-DIN 6-pin</a></h3>
+            <h3><a href="pinouts.md#ps2">PS/2 Mini-DIN 6-pin</a></h3>
             <div class="sample-image">
               <img src="images/Data/PS2_cork1.jpg">
               <img src="images/Data/PS2_cork2.jpg">
@@ -1735,7 +1735,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-20">USB 2.0 Type A</a></h3>
+              <h3><a href="pinouts.md#usb-20">USB 2.0 Type A</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB2_typeA_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.what-is-my-computer.com/images/usb-ports.jpg">
               </div>
@@ -1752,7 +1752,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-20">USB 2.0 Type B</a></h3>
+              <h3><a href="pinouts.md#usb-20">USB 2.0 Type B</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/techinfo/usb_info_type-b.jpg">
               </div>
@@ -1769,7 +1769,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-20">USB 2.0 Mini A</a></h3>
+              <h3><a href="pinouts.md#usb-20">USB 2.0 Mini A</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB2_miniA_cork.jpg">
               </div>
@@ -1786,7 +1786,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-20">USB 2.0 Mini B 5-pin</a></h3>
+              <h3><a href="pinouts.md#usb-20">USB 2.0 Mini B 5-pin</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB2_miniB_cork.jpg">
               </div>
@@ -1817,7 +1817,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-20">USB 2.0 Micro A</a></h3>
+              <h3><a href="pinouts.md#usb-20">USB 2.0 Micro A</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB2_microA_cork.jpg">
               </div>
@@ -1834,7 +1834,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-20">USB 2.0 Micro B</a></h3>
+              <h3><a href="pinouts.md#usb-20">USB 2.0 Micro B</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB2_microB_cork.jpg">
               </div>
@@ -1862,7 +1862,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-30">USB 3.0 Type A</a></h3>
+              <h3><a href="pinouts.md#usb-30">USB 3.0 Type A</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB3_typeA_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/7/75/Connector_USB_3_IMGP6024_wp.jpg">
                 <img src="images/Data/USB3_typeA_bottle1.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn8.digitaltrends.com/image/usb-3-0-ports-625x300-c.jpg">
@@ -1881,7 +1881,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-30">USB 3.0 Type B</a></h3>
+              <h3><a href="pinouts.md#usb-30">USB 3.0 Type B</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB3_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/usb_3_b.jpg">
                 <img src="images/Data/USB3_typeB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://hsto.org/getpro/habr/post_images/c40/af2/062/c40af20620352d5a35b1cadb413bc739.jpg">
@@ -1899,7 +1899,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-30">USB 3.0 Micro B</a></h3>
+              <h3><a href="pinouts.md#usb-30">USB 3.0 Micro B</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB3_microB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/USB3SAUBX.C.jpg">
                 <img src="images/Data/USB3_microB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://farm6.staticflickr.com/5590/14717534619_7bf547c241_o.jpg">
@@ -1927,7 +1927,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-31">USB 3.1 Type C</a></h3>
+              <h3><a href="pinouts.md#usb-31">USB 3.1 Type C</a></h3>
               <div class="sample-image">
                 <img src="images/Data/USB3-1_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cnet2.cbsistatic.com/img/JplrP5OaMw-Qjju0FM-E9SJEPIs=/570x0/2015/12/07/fcf70d65-4104-465e-b017-c5af7e122527/20151203-usb-type-c-001.jpg">
                 <img src="images/Data/USB3-1_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://liliputing.com/wp-content/uploads/2015/03/macbook-type-c2.jpg">
@@ -1963,7 +1963,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#6-pin">FireWire 400 6-pin</a></h3>
+              <h3><a href="pinouts.md#6-pin">FireWire 400 6-pin</a></h3>
               <div class="sample-image">
                 <img src="images/firewire_6-pin.jpg">
                 <img src="images/Data/firewire_6-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://etc.usf.edu/te_mac/hardware/i/img_1744.jpg">
@@ -1981,7 +1981,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#4-pin">FireWire 400 4-pin</a></h3>
+              <h3><a href="pinouts.md#4-pin">FireWire 400 4-pin</a></h3>
               <div class="sample-image">
                 <img src="images/firewire_4-pin.jpg">
                 <img src="images/Data/firewire_4-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.jontrosky.com/images/firewire_4_pin_port.jpg">
@@ -2008,7 +2008,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#9-pin">FireWire 800 9-pin</a></h3>
+              <h3><a href="pinouts.md#9-pin">FireWire 800 9-pin</a></h3>
               <div class="sample-image">
                 <img src="images/Data/firewire_9-pin_cork.jpg">
                 <img src="images/Data/firewire_9-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-image.realsimple.com/sites/default/files/styles/rs_main_image/public/image/images/0809/firewire-800-port_300.jpg?itok=UMxZPpBw">
@@ -2042,7 +2042,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#displayport">Thunderbolt 1 and 2 Mini-DisplayPort</a></h3>
+              <h3><a href="pinouts.md#displayport">Thunderbolt 1 and 2 Mini-DisplayPort</a></h3>
               <div class="sample-image">
                 <img src="images/Data/thunderbolt_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/TBOLTMMXMW.D.jpg">
                 <img src="images/Data/thunderbolt_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://support.seagate.com/kbimg/004528-1.jpg">
@@ -2069,7 +2069,7 @@
             <div class="modal-dialog modal-lg">
             <div class="modal-content">
             <div class="well">
-              <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#usb-31">Thunderbolt 3 USB Type C</a></h3>
+              <h3><a href="pinouts.md#usb-31">Thunderbolt 3 USB Type C</a></h3>
               <div class="sample-image">
                 <img src="images/Data/thunderbolt_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.flatpanelshd.com/pictures/thunderbolt3-1l.jpg">
                 <img src="images/Data/thunderbolt_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blogs.intel.com/technology/files/2015/08/Lenovo-ports.jpg">

--- a/index.html
+++ b/index.html
@@ -38,131 +38,143 @@
 
 <div class="well col-md-8 col-md-offset-0">
 
-  <!-- TABLE OF CONTENTS -->
-  <div class="well" id="table_of_contents">
-    <h2>What kind of cable are you looking for?</h2>
-    <ol type="I">
-      <li><a href="#video">Video</a>
+<!-- TABLE OF CONTENTS -->
+<div class="well" id="table_of_contents">
+  <h2>What kind of cable are you looking for?</h2>
+  <ol type="I">
+    <li><a href="#video">Video</a>
       <ol type="A">
-      <li><a href="#analog_video">Analog Video</a>
-        <ol type="1">
-        <li><a href="#composite">Composite</a></li>
-        <li><a href="#component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></a></li>
-        <li><a href="#s-video">S-Video</a></li>
-        <li><a href="#rgbs">RGBS</a></li>
-        <li><a href="#rgbvh">RGBVH</a></li>
-        </ol></li>
-      <li><a href="#digital_video">Digital Video</a>
-        <ol type="1">
-        <li><a href="#sdi">SDI</a></li>
-        <li><a href="#firewire_video">FireWire (IEEE 1394)</a></li>
-        <li><a href="#dvi">DVI</a></li>
-        <li><a href="#displayport">DisplayPort</a></li>
-        <li><a href="#hdmi">HDMI</a></li>
-        </ol></li>
-      <li><a href="#integrated_video">Integrated Video</a>
-        <ol type="1">
-        <li><a href="#dvi-i">DVI-I</a></li>
-        </ol></li>
-      </ol></li>
+        <li><a href="#analog_video">Analog Video</a>
+          <ol type="1">
+            <li><a href="#composite">Composite</a></li>
+            <li><a href="#component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></a></li>
+            <li><a href="#s-video">S-Video</a></li>
+            <li><a href="#rgbs">RGBS</a></li>
+            <li><a href="#rgbvh">RGBVH</a></li>
+          </ol>
+        </li>
+        <li><a href="#digital_video">Digital Video</a>
+          <ol type="1">
+            <li><a href="#sdi">SDI</a></li>
+            <li><a href="#firewire_video">FireWire (IEEE 1394)</a></li>
+            <li><a href="#dvi">DVI</a></li>
+            <li><a href="#displayport">DisplayPort</a></li>
+            <li><a href="#hdmi">HDMI</a></li>
+          </ol>
+        </li>
+        <li><a href="#integrated_video">Integrated Video</a>
+          <ol type="1">
+            <li><a href="#dvi-i">DVI-I</a></li>
+          </ol>
+        </li>
+      </ol>
+    </li>
     <li><a href="#audio">Audio</a>
       <ol type="A">
-      <li><a href="#analog_audio">Analog Audio</a>
-        <ol type="1">
-        <li><a href="#balanced_analog">Balanced</a></li>
-        <li><a href="#unbalanced_analog">Unbalanced</a></li>
-        </ol></li>
-      <li><a href="#digital_audio">Digital Audio</a>
-        <ol type="1">
-        <li><a href="#aes-3">AES-3 (AES-EBU)</a></li>
-        <li><a href="#spdif">S/PDIF</a></li>
-        <li><a href="#midi">MIDI</a></li>
-        <li><a href="#tdif">TDIF</a></li>
-        <li><a href="#adat">ADAT</a></li>
-        </ol></li>
-      </ol></li>
+        <li><a href="#analog_audio">Analog Audio</a>
+          <ol type="1">
+            <li><a href="#balanced_analog">Balanced</a></li>
+            <li><a href="#unbalanced_analog">Unbalanced</a></li>
+          </ol>
+        </li>
+        <li><a href="#digital_audio">Digital Audio</a>
+          <ol type="1">
+            <li><a href="#aes-3">AES-3 (AES-EBU)</a></li>
+            <li><a href="#spdif">S/PDIF</a></li>
+            <li><a href="#midi">MIDI</a></li>
+            <li><a href="#tdif">TDIF</a></li>
+            <li><a href="#adat">ADAT</a></li>
+          </ol>
+        </li>
+      </ol>
+    </li>
     <li><a href="#data">Data</a>
       <ol type="A">
-      <li><a href="#parallel_data">Parallel Data</a>
-        <ol type="1">
-        <li><a href="#pata">PATA</a></li>
-        <li><a href="#parallel_scsi">Parellel SCSI</a></li>
-        <li><a href="#parallel_port">IEEE 1284 "Parallel Port"</a></li>
-        </ol></li>
-      <li><a href="#serial_data">Serial Data</a>
-        <ol type="1">
-        <li><a href="#rs-232">RS-232 "Serial Port"</a></li>
-        <li><a href="#rs-422">RS-422</a></li>
-        <li><a href="#sas">SAS (Serial Attached SCSI)</a></li>
-        <li><a href="#sata">SATA</a></li>
-        <li><a href="#apple_desktop_bus">Apple Desktop Bus</a></li>
-        <li><a href="#ps2">PS/2</a></li>
-        <li><a href="#usb">USB</a></li>
-        <li><a href="#firewire_data">FireWire</a></li>
-        <li><a href="#thunderbolt">Thunderbolt</a></li>
-        <li><a href="#hdbaset">HDBaseT</a></li>
-        </ol></li>
-      </ol></li>
+        <li><a href="#parallel_data">Parallel Data</a>
+          <ol type="1">
+            <li><a href="#pata">PATA</a></li>
+            <li><a href="#parallel_scsi">Parellel SCSI</a></li>
+            <li><a href="#parallel_port">IEEE 1284 "Parallel Port"</a></li>
+          </ol>
+        </li>
+        <li><a href="#serial_data">Serial Data</a>
+          <ol type="1">
+            <li><a href="#rs-232">RS-232 "Serial Port"</a></li>
+            <li><a href="#rs-422">RS-422</a></li>
+            <li><a href="#sas">SAS (Serial Attached SCSI)</a></li>
+            <li><a href="#sata">SATA</a></li>
+            <li><a href="#apple_desktop_bus">Apple Desktop Bus</a></li>
+            <li><a href="#ps2">PS/2</a></li>
+            <li><a href="#usb">USB</a></li>
+            <li><a href="#firewire_data">FireWire</a></li>
+            <li><a href="#thunderbolt">Thunderbolt</a></li>
+            <li><a href="#hdbaset">HDBaseT</a></li>
+          </ol>
+        </li>
+      </ol>
+    </li>
     <li><a href="#power">Power</a></li>
-    </ol>
-  </div>
+  </ol>
+</div>
 
-  <!-- start Video cables -->
+<!-- start Video cables -->
+<div class="well">
+  <h2 id="video"><u>Video</u></h2>
 
-  <div class="well"><h2 id="video"><u>Video</u></h2>
-    <!-- start Analog Video cables -->
+<!-- start Analog Video cables -->
+<div class="well">
+  <h3 id="analog_video">Analog Video</h3>
+  <p>Analog audiovisual media record image and sound information as a continuous signal stored in or on the media itself (in the case of most "video" formats, as a continually fluctuating level of magnetic field strength on tape). Different types of video processing can allow that signal to be carried along different channels, with each channel representing a different portion of the video information (e.g. luminance/brightness, chrominance/color, sync). The types of cable you will need to work with an analog video signal will depend primarily on how these channels have been divided, as well as considerations of signal-to-noise ratio - all analog signals are subject to some degree of electronic noise or distortion, and different connection standards and interfaces have been developed to combat such signal degradation.</p>
 
-    <div class="well"><h3 id="analog_video">Analog Video</h3>
-      <p>Analog audiovisual media record image and sound information as a continuous signal stored in or on the media itself (in the case of most "video" formats, as a continually fluctuating level of magnetic field strength on tape). Different types of video processing can allow that signal to be carried along different channels, with each channel representing a different portion of the video information (e.g. luminance/brightness, chrominance/color, sync). The types of cable you will need to work with an analog video signal will depend primarily on how these channels have been divided, as well as considerations of signal-to-noise ratio - all analog signals are subject to some degree of electronic noise or distortion, and different connection standards and interfaces have been developed to combat such signal degradation.</p>
+<!-- start Composite protocol cables -->
+<div class="well">
+  <h4 id="composite">Composite</h4>
+  <p>In composite cables, all video information (including both luminance and chrominance) is encoded on to a single channel/wire. As all information is traveling along one channel, composite video is the most susceptible to noise in the signal.</p>
+  <p><b>Introduced:</b> 1956</p>
+  <p><b>Max resolution:</b> Standard Definition (typically 480i or 576i)</p>
+  <p><b>Connectors:</b></p>
 
-    <!-- start Composite protocol cables -->
-      <div class="well"><h4 id="composite">Composite</h4>
-        <p>In composite cables, all video information (including both luminance and chrominance) is encoded on to a single channel/wire. As all information is traveling along one channel, composite video is the most susceptible to noise in the signal.</p>
-        <p><b>Introduced:</b> 1956</p>
-        <p><b>Max resolution:</b> Standard Definition (typically 480i or 576i)</p>
-        <p><b>Connectors:</b></p>
-
-  <!-- Composite RCA -->
-  <span data-toggle="modal" data-target="#composite_RCA"><button type="button" class="btn btn-default"><img src="images/composite_RCA.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
-  <div id="composite_RCA" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#rca">Composite RCA</a></h3>
-          <div class="sample-image">
-            <img src="images/composite_RCA.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/c/cd/Composite-video-cable.jpg">
-            <img src="images/Video/composite_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.doom9.org/capture/images/CompositeJack.jpeg">
-          </div>
-          <p>Used primarily with consumer equipment (e.g. Betamax, VHS, DVD).</p>
-          <p>Audio: no</p>
+<!-- Composite RCA -->
+<span data-toggle="modal" data-target="#composite_RCA"><button type="button" class="btn btn-default"><img src="images/composite_RCA.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
+<div id="composite_RCA" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#rca">Composite RCA</a></h3>
+        <div class="sample-image">
+          <img src="images/composite_RCA.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/c/cd/Composite-video-cable.jpg">
+          <img src="images/Video/composite_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.doom9.org/capture/images/CompositeJack.jpeg">
         </div>
+        <p>Used primarily with consumer equipment (e.g. Betamax, VHS, DVD).</p>
+        <p>Audio: no</p>
       </div>
     </div>
   </div>
-  <!-- end Composite RCA -->
+</div>
+<!-- end Composite RCA -->
 
-  <!-- Composite BNC -->
-  <span data-toggle="modal" data-target="#composite_BNC"><button type="button" class="btn btn-default"><img src="images/Video/BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
-  <div id="composite_BNC" class="modal fade" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#bnc">Composite BNC</a></h3>
-          <div class="sample-image">
-            <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
-            <img src="images/Video/composite_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/FME-Female-to-BNC-Female-Adaptor.jpg">
-          </div>
-          <p>Used in professional broadcast and some consumer equipment.</p>
-          <p>Audio: no</p>
+<!-- Composite BNC -->
+<span data-toggle="modal" data-target="#composite_BNC"><button type="button" class="btn btn-default"><img src="images/Video/BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
+<div id="composite_BNC" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#bnc">Composite BNC</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
+          <img src="images/Video/composite_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/FME-Female-to-BNC-Female-Adaptor.jpg">
         </div>
+        <p>Used in professional broadcast and some consumer equipment.</p>
+        <p>Audio: no</p>
       </div>
     </div>
   </div>
-  <!-- end Composite BNC -->
+</div>
+<!-- end Composite BNC -->
 
 <!-- Composite UHF -->
-  <span data-toggle="modal" data-target="#composite_UHF"><button type="button" class="btn btn-default"><img src="images/Video/composite_UHF_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">UHF</button></span>
-  <div id="composite_UHF" class="modal fade" tabindex="-1" role="dialog">
+<span data-toggle="modal" data-target="#composite_UHF"><button type="button" class="btn btn-default"><img src="images/Video/composite_UHF_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">UHF</button></span>
+<div id="composite_UHF" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -176,12 +188,12 @@
       </div>
     </div>
   </div>
-  </div>
-  <!--end Composite UHF -->
+</div>
+<!--end Composite UHF -->
 
-  <!-- Composite F-Type -->
-  <span data-toggle="modal" data-target="#composite_F-type"><button type="button" class="btn btn-default"><img src="images/composite_F-type.jpg" class="img-responsive" style="max-height:100px; width:auto;">F-Type</button></span>
-  <div id="composite_F-type" class="modal fade" tabindex="-1" role="dialog">
+<!-- Composite F-Type -->
+<span data-toggle="modal" data-target="#composite_F-type"><button type="button" class="btn btn-default"><img src="images/composite_F-type.jpg" class="img-responsive" style="max-height:100px; width:auto;">F-Type</button></span>
+<div id="composite_F-type" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -195,12 +207,12 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end Composite F-Type -->
+</div>
+<!-- end Composite F-Type -->
 
-  <!-- Composite Video Patch (MUSA) -->
-  <span data-toggle="modal" data-target="#composite_video-patch"><button type="button" class="btn btn-default"><img src="images/Video/composite_video-patch_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Video Patch (MUSA)</button></span>
-  <div id="composite_video-patch" class="modal fade" tabindex="-1" role="dialog">
+<!-- Composite Video Patch (MUSA) -->
+<span data-toggle="modal" data-target="#composite_video-patch"><button type="button" class="btn btn-default"><img src="images/Video/composite_video-patch_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Video Patch (MUSA)</button></span>
+<div id="composite_video-patch" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -214,12 +226,12 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end Composite Video Patch (MUSA) -->
+</div>
+<!-- end Composite Video Patch (MUSA) -->
 
-  <!-- Composite 8-Pin EIAJ -->
-  <span data-toggle="modal" data-target="#composite_eiaj"><button type="button" class="btn btn-default"><img src="images/Video/composite_eiaj_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">8-pin EIAJ</button></span>
-  <div id="composite_eiaj" class="modal fade" tabindex="-1" role="dialog">
+<!-- Composite 8-Pin EIAJ -->
+<span data-toggle="modal" data-target="#composite_eiaj"><button type="button" class="btn btn-default"><img src="images/Video/composite_eiaj_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">8-pin EIAJ</button></span>
+<div id="composite_eiaj" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -233,12 +245,12 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end Composite 8-pin EIAJ -->
+</div>
+<!-- end Composite 8-pin EIAJ -->
 
-  <!-- Composite SCART -->
-  <span data-toggle="modal" data-target="#composite_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
-  <div id="composite_scart" class="modal fade" tabindex="-1" role="dialog">
+<!-- Composite SCART -->
+<span data-toggle="modal" data-target="#composite_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
+<div id="composite_scart" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -252,89 +264,89 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end Composite SCART -->
+</div>
+<!-- end Composite SCART -->
 
-  </div><!-- end Composite well -->
-
+</div> <!-- end Composite well -->
 
 <!-- start Component YPbPr cables -->
-  <div class="well"><h4 id="component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></h4>
-    <p>Y′P<sub>B</sub>P<sub>R</sub> signal is often referred to, imprecisely, simply as "component" video, although there are actually several standards of component video (any signal standard that splits video information into multiple channels is component, including S-Video and the multiple RGB standards). In Y′P<sub>B</sub>P<sub>R</sub>, the video signal is split into three channels: Y (containing luminance and sync), P<sub>B</sub> (the difference between blue and luma), and P<sub>R</sub> (the difference between red and luma). The remaining (green) chrominance information is derived from the relationship between these three signals. Y′P<sub>B</sub>P<sub>R</sub> cables are sometimes referred to as "yipper" cables and are connectors are usually color-coded (Y&nbsp;=&nbsp;green, P<sub>B</sub>&nbsp;=&nbsp;blue, P<sub>R</sub>&nbsp;=&nbsp;red); however Y′P<sub>B</sub>P<sub>R</sub> cables are fundamentally wired the same as composite cables and can be used interchangeably as long as the corresponding ports are properly connected.</p>
-    <p><b>Introduced:</b>unknown</p>
-    <p><b>Max resolution:</b> High Definition (up to 1080p)</p>
-    <p><b>Connectors:</b></p>
+<div class="well">
+  <h4 id="component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></h4>
+  <p>Y′P<sub>B</sub>P<sub>R</sub> signal is often referred to, imprecisely, simply as "component" video, although there are actually several standards of component video (any signal standard that splits video information into multiple channels is component, including S-Video and the multiple RGB standards). In Y′P<sub>B</sub>P<sub>R</sub>, the video signal is split into three channels: Y (containing luminance and sync), P<sub>B</sub> (the difference between blue and luma), and P<sub>R</sub> (the difference between red and luma). The remaining (green) chrominance information is derived from the relationship between these three signals. Y′P<sub>B</sub>P<sub>R</sub> cables are sometimes referred to as "yipper" cables and are connectors are usually color-coded (Y&nbsp;=&nbsp;green, P<sub>B</sub>&nbsp;=&nbsp;blue, P<sub>R</sub>&nbsp;=&nbsp;red); however Y′P<sub>B</sub>P<sub>R</sub> cables are fundamentally wired the same as composite cables and can be used interchangeably as long as the corresponding ports are properly connected.</p>
+  <p><b>Introduced:</b>unknown</p>
+  <p><b>Max resolution:</b> High Definition (up to 1080p)</p>
+  <p><b>Connectors:</b></p>
 
 <!-- Component YPbPr RCA -->
 <span data-toggle="modal" data-target="#component_rca"><button type="button" class="btn btn-default"><img src="images/component_rca.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
 <div id="component_rca" class="modal fade" tabindex="-1" role="dialog">
-<div class="modal-dialog modal-lg">
-  <div class="modal-content">
-    <div class="well">
-      <h3><a href="pinouts.md#rca">Component Y′P<sub>B</sub>P<sub>R</sub> RCA</a></h3>
-      <div class="sample-image">
-        <img src="images/component_rca.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/1d/Component-cables.jpg">
-        <img src="images/Video/component_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ef/Component_video_jack.jpg">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#rca">Component Y′P<sub>B</sub>P<sub>R</sub> RCA</a></h3>
+        <div class="sample-image">
+          <img src="images/component_rca.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/1d/Component-cables.jpg">
+          <img src="images/Video/component_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ef/Component_video_jack.jpg">
+        </div>
+        <p>Used primarily with consumer equipment.</p>
+        <p>Audio: no</p>
       </div>
-      <p>Used primarily with consumer equipment.</p>
-      <p>Audio: no</p>
     </div>
   </div>
-</div>
 </div>
 <!-- end Component YPbPr RCA -->
 
 <!-- Component YPbPr BNC -->
 <span data-toggle="modal" data-target="#component_bnc"><button type="button" class="btn btn-default"><img src="images/Video/component_bnc_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
 <div id="component_bnc" class="modal fade" tabindex="-1" role="dialog">
-<div class="modal-dialog modal-lg">
-  <div class="modal-content">
-    <div class="well">
-      <h3><a href="pinouts.md#bnc">Component Y′P<sub>B</sub>P<sub>R</sub> BNC</a></h3>
-      <div class="sample-image">
-        <img src="images/Video/component_bnc_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/Python-3-BNC-To-3-RCA-Component-Video-Cable-4.jpg">
-        <img src="images/Video/component_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://salestores.com/stores/images/images_747/AVOV3HDF.jpg">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#bnc">Component Y′P<sub>B</sub>P<sub>R</sub> BNC</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/component_bnc_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/Python-3-BNC-To-3-RCA-Component-Video-Cable-4.jpg">
+          <img src="images/Video/component_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://salestores.com/stores/images/images_747/AVOV3HDF.jpg">
+        </div>
+        <p>Seen with professional broadcast and production equipment, some consumer electronics.</p>
+        <p>Audio: no</p>
       </div>
-      <p>Seen with professional broadcast and production equipment, some consumer electronics.</p>
-      <p>Audio: no</p>
     </div>
   </div>
-</div>
 </div>
 <!-- end Component YPbPr BNC -->
 
 <!-- Component YPbPr SCART -->
 <span data-toggle="modal" data-target="#component_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
 <div id="component_scart" class="modal fade" tabindex="-1" role="dialog">
-<div class="modal-dialog modal-lg">
-  <div class="modal-content">
-    <div class="well">
-      <h3><a href="pinouts.md#scart">Component Y′P<sub>B</sub>P<sub>R</sub> SCART</a></h3>
-      <div class="sample-image">
-        <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
-        <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#scart">Component Y′P<sub>B</sub>P<sub>R</sub> SCART</a></h3>
+        <div class="sample-image">
+          <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
+          <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
+        </div>
+        <p>European 21-pin connector designed to be capable of carrying both input and output of multiple signal standards; a Y′P<sub>B</sub>P<sub>R</sub> pinout is possible with a SCART connector but extremely rare as European monitors generally did not support Y′P<sub>B</sub>P<sub>R</sub> input.</p>
+        <p>Audio: yes, stereo, unbalanced</p>
       </div>
-      <p>European 21-pin connector designed to be capable of carrying both input and output of multiple signal standards; a Y′P<sub>B</sub>P<sub>R</sub> pinout is possible with a SCART connector but extremely rare as European monitors generally did not support Y′P<sub>B</sub>P<sub>R</sub> input.</p>
-      <p>Audio: yes, stereo, unbalanced</p>
     </div>
   </div>
 </div>
-</div>
 <!-- end Component YPbPr SCART -->
 
-  </div><!-- end Component YPbPr well -->
+</div> <!-- end Component YPbPr well -->
 
+<!-- start Analog S-Video protocol cables -->
+<div class="well">
+  <h4 id="s-video">S-Video</h4>
+  <p>S-Video (sometimes known as "separate video") cables carry video over two synchronized signal channels: Y (luma) and C (chroma, including saturation and hue). It can achieve better image quality than composite but lower color resolution than component RGB or Y′P<sub>B</sub>P<sub>R</sub> video. Most often associated with S-VHS but found with many other consumer deck formats as well.</p>
+  <p><b>Introduced:</b>unknown</p>
+  <p><b>Max resolution:</b> Standard Definition (typically 480i or 576i)</p>
+  <p><b>Connectors:</b></p>
 
-  <!-- start Analog S-Video protocol cables -->
-    <div class="well"><h4 id="s-video">S-Video</h4>
-      <p>S-Video (sometimes known as "separate video") cables carry video over two synchronized signal channels: Y (luma) and C (chroma, including saturation and hue). It can achieve better image quality than composite but lower color resolution than component RGB or Y′P<sub>B</sub>P<sub>R</sub> video. Most often associated with S-VHS but found with many other consumer deck formats as well.</p>
-      <p><b>Introduced:</b>unknown</p>
-      <p><b>Max resolution:</b> Standard Definition (typically 480i or 576i)</p>
-      <p><b>Connectors:</b></p>
-
-  <!-- S-Video Mini-DIN 4-pin -->
-  <span data-toggle="modal" data-target="#s-video_mini-din-4-pin"><button type="button" class="btn btn-default"><img src="images/S-video.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DIN 4-pin</button></span>
-  <div id="s-video_mini-din-4-pin" class="modal fade" tabindex="-1" role="dialog">
+<!-- S-Video Mini-DIN 4-pin -->
+<span data-toggle="modal" data-target="#s-video_mini-din-4-pin"><button type="button" class="btn btn-default"><img src="images/S-video.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DIN 4-pin</button></span>
+<div id="s-video_mini-din-4-pin" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -348,12 +360,12 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end S-Video Mini-DIN 4-pin -->
+</div>
+<!-- end S-Video Mini-DIN 4-pin -->
 
-  <!-- S-Video BNC -->
-  <span data-toggle="modal" data-target="#s-video_bnc"><button type="button" class="btn btn-default"><img src="images/Video/s-video_bnc_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
-  <div id="s-video_bnc" class="modal fade" tabindex="-1" role="dialog">
+<!-- S-Video BNC -->
+<span data-toggle="modal" data-target="#s-video_bnc"><button type="button" class="btn btn-default"><img src="images/Video/s-video_bnc_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
+<div id="s-video_bnc" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -366,12 +378,12 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end S-Video BNC -->
+</div>
+<!-- end S-Video BNC -->
 
-  <!-- S-Video SCART -->
-  <span data-toggle="modal" data-target="#s-video_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
-  <div id="s-video_scart" class="modal fade" tabindex="-1" role="dialog">
+<!-- S-Video SCART -->
+<span data-toggle="modal" data-target="#s-video_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
+<div id="s-video_scart" class="modal fade" tabindex="-1" role="dialog">
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="well">
@@ -385,1742 +397,1765 @@
       </div>
     </div>
   </div>
-  </div>
-  <!-- end S-Video SCART -->
+</div>
+<!-- end S-Video SCART -->
 
-    </div><!--end S-Video well -->
+</div> <!--end S-Video well -->
 
 <!-- start Analog RGBS protocol cables -->
-      <div class="well"><h4 id="rgbs">RGBS</h4>
-        <p>A component video standard in which luminance and chrominance information is encoded into three channels (red, green and blue) and a fourth is used for composite sync (vertical and horizontal sync encoded together on the same wire). RGBS utilizes no compression and has no particular limit on color depth or resolution, but requires a high bandwidth as the three channels carry much redundant information (i.e. the same black-and-white luma information repeated three times). Extremely common in European equipment (especially monitors), rare elsewhere.</p>
-        <p><b>Introduced:</b>unknown</p>
-        <p><b>Max resolution:</b> Generally up to 1080p (HD), but can go beyond</p>
-        <p><b>Connectors:</b></p>
+<div class="well">
+  <h4 id="rgbs">RGBS</h4>
+  <p>A component video standard in which luminance and chrominance information is encoded into three channels (red, green and blue) and a fourth is used for composite sync (vertical and horizontal sync encoded together on the same wire). RGBS utilizes no compression and has no particular limit on color depth or resolution, but requires a high bandwidth as the three channels carry much redundant information (i.e. the same black-and-white luma information repeated three times). Extremely common in European equipment (especially monitors), rare elsewhere.</p>
+  <p><b>Introduced:</b>unknown</p>
+  <p><b>Max resolution:</b> Generally up to 1080p (HD), but can go beyond</p>
+  <p><b>Connectors:</b></p>
 
-        <!-- RGBS SCART -->
-        <span data-toggle="modal" data-target="#rgbs_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
-        <div id="rgbs_scart" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#scart">RGBS SCART</a></h3>
-              <div class="sample-image">
-                <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
-                <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
-              </div>
-              <p>European 21-pin connector designed to be capable of carrying both input and output of multiple signal standards. RGBS cables most frequently have SCART connectors and vice versa.</p>
-              <p>Audio: yes, stereo, unbalanced</p>
-            </div>
-          </div>
+<!-- RGBS SCART -->
+<span data-toggle="modal" data-target="#rgbs_scart"><button type="button" class="btn btn-default"><img src="images/SCART.jpg" class="img-responsive" style="max-height:100px; width:auto;">SCART</button></span>
+<div id="rgbs_scart" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#scart">RGBS SCART</a></h3>
+        <div class="sample-image">
+          <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
+          <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">
         </div>
+        <p>European 21-pin connector designed to be capable of carrying both input and output of multiple signal standards. RGBS cables most frequently have SCART connectors and vice versa.</p>
+        <p>Audio: yes, stereo, unbalanced</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RGBS SCART -->
+
+</div> <!-- end RGBS well -->
+
+<!-- start Analog RGBVH protocol cables -->
+<div class="well">
+  <h4 id="rgbvh">RGBVH</h4>
+  <p>A component video standard essentially the same as RGBS, except the sync signal is split into vertical and horizontal sync on separate wires. Most frequently employed in the context of the Video Graphics Array (VGA) display standard.</p>
+  <p><b>Introduced:</b>unknown</p>
+  <p><b>Max resolution:</b> Generally up to 1080p (HD), but can go beyond</p>
+  <p><b>Connectors:</b></p>
+
+<!-- RGBVH VGA -->
+<span data-toggle="modal" data-target="#rgbvh_vga"><button type="button" class="btn btn-default"><img src="images/Video/VGA_D-sub15_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">VGA (DE-15)</button></span>
+<div id="rgbvh_vga" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#vga">RGBVH VGA (DE-15)</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/VGA_D-sub15_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Male_VGA_connector.jpg/170px-Male_VGA_connector.jpg">
+          <img src="images/Video/vga_d-sub15_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Male_VGA_connector.jpg/170px-Male_VGA_connector.jpg">
         </div>
-        <!-- end RGBS SCART -->
+        <p>A 15-pin D-sub connector commonly offered on modern computers for display connections.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RGBVH VGA -->
 
-      </div><!-- end RGBS well -->
+<!-- RGBVH Mini-VGA -->
+<span data-toggle="modal" data-target="#rgbvh_mini-VGA"><button type="button" class="btn btn-default"><img src="images/VGA-mini.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-VGA</button></span>
+<div id="rgbvh_mini-VGA" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#mini-vga">RGBVH Mini-VGA</a></h3>
+        <div class="sample-image">
+          <img src="images/VGA-mini.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/5/57/Mini-VGA-Connector.jpg">
+          <img src="images/Video/vga_mini-vga_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Mini-VGA_cropped.jpg/250px-Mini-VGA_cropped.jpg">
+        </div>
+        <p>Used to adapt VGA/RGBVH signals input and output for laptop computers.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RGBVH Mini-VGA -->
 
-      <!-- start Analog RGBVH protocol cables -->
-            <div class="well"><h4 id="rgbvh">RGBVH</h4>
-              <p>A component video standard essentially the same as RGBS, except the sync signal is split into vertical and horizontal sync on separate wires. Most frequently employed in the context of the Video Graphics Array (VGA) display standard.</p>
-              <p><b>Introduced:</b>unknown</p>
-              <p><b>Max resolution:</b> Generally up to 1080p (HD), but can go beyond</p>
-              <p><b>Connectors:</b></p>
+<!-- RGBVH BNC -->
+<span data-toggle="modal" data-target="#rgbvh_bnc"><button type="button" class="btn btn-default"><img src="images/Video/RGBVH_BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
+<div id="rgbvh_bnc" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#bnc">RGBVH BNC</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/RGBVH_BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/83/BNC_connectors.jpg">
+        </div>
+        <p>Found with some high-end monitors and video cards. Wires are usually color-coded, though the colors used for the two sync signals sometimes varies: e.g. yellow (H) and white (V), yellow (H) and black (V), gray (H) and black (V).</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RGBVH BNC -->
 
-              <!-- RGBVH VGA -->
-              <span data-toggle="modal" data-target="#rgbvh_vga"><button type="button" class="btn btn-default"><img src="images/Video/VGA_D-sub15_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">VGA (DE-15)</button></span>
-              <div id="rgbvh_vga" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                  <div class="well">
-                    <h3><a href="pinouts.md#vga">RGBVH VGA (DE-15)</a></h3>
-                    <div class="sample-image">
-                      <img src="images/Video/VGA_D-sub15_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Male_VGA_connector.jpg/170px-Male_VGA_connector.jpg">
-                      <img src="images/Video/vga_d-sub15_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Male_VGA_connector.jpg/170px-Male_VGA_connector.jpg">
-                    </div>
-                    <p>A 15-pin D-sub connector commonly offered on modern computers for display connections.</p>
-                    <p>Audio: no</p>
-                  </div>
-                </div>
-              </div>
-              </div>
-              <!-- end RGBVH VGA -->
+<!-- RGBVH DVI-A -->
+<span data-toggle="modal" data-target="#rgbvh_dvi-a"><button type="button" class="btn btn-default"><img src="images/Video/dvi-a_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DVI-A</button></span>
+<div id="rgbvh_dvi-a" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#dvi">RGBVH DVI-A</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi-a_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://rubimages-liberty.netdna-ssl.com/hi-res/E-DVI_A-5BNCM_DVIend.png">
+          <img src="images/Video/dvi-a_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.bhs4.com/07/A/07A6C8140CC3555552F53D6859963A86DC347FE2_large.jpg">
+        </div>
+        <p>Much more frequently found in its DVI-I and DVI-D flavors, Digital Video Interface (DVI) is designed to transmit uncompressed digital video information, but can be compatible with analog RGBVH video through the VGA interface. DVI-A (analog) cables and connectors are essentially the same electrically as VGA cables and connectors.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RGBVH DVI-A -->
 
-              <!-- RGBVH Mini-VGA -->
-              <span data-toggle="modal" data-target="#rgbvh_mini-VGA"><button type="button" class="btn btn-default"><img src="images/VGA-mini.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-VGA</button></span>
-              <div id="rgbvh_mini-VGA" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                  <div class="well">
-                    <h3><a href="pinouts.md#mini-vga">RGBVH Mini-VGA</a></h3>
-                    <div class="sample-image">
-                      <img src="images/VGA-mini.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/5/57/Mini-VGA-Connector.jpg">
-                      <img src="images/Video/vga_mini-vga_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Mini-VGA_cropped.jpg/250px-Mini-VGA_cropped.jpg">
-                    </div>
-                    <p>Used to adapt VGA/RGBVH signals input and output for laptop computers.</p>
-                    <p>Audio: no</p>
-                  </div>
-                </div>
-              </div>
-              </div>
-              <!-- end RGBVH Mini-VGA -->
+<!-- RGBVH Mini-DVI -->
+<span data-toggle="modal" data-target="#rgbvh_mini-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi_mini-DVI_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DVI</button></span>
+<div id="rgbvh_mini-dvi" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#mini-dvi">RGBVH Mini-DVI</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
+          <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
+        </div>
+        <p>Used on certain Apple computers, especially laptops, to accept a DVI-A/VGA connection.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RGBVH Mini-DVI -->
 
-              <!-- RGBVH BNC -->
-              <span data-toggle="modal" data-target="#rgbvh_bnc"><button type="button" class="btn btn-default"><img src="images/Video/RGBVH_BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
-              <div id="rgbvh_bnc" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                  <div class="well">
-                    <h3><a href="pinouts.md#bnc">RGBVH BNC</a></h3>
-                    <div class="sample-image">
-                      <img src="images/Video/RGBVH_BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/83/BNC_connectors.jpg">
-                    </div>
-                    <p>Found with some high-end monitors and video cards. Wires are usually color-coded, though the colors used for the two sync signals sometimes varies: e.g. yellow (H) and white (V), yellow (H) and black (V), gray (H) and black (V).</p>
-                    <p>Audio: no</p>
-                  </div>
-                </div>
-              </div>
-              </div>
-              <!-- end RGBVH BNC -->
+</div> <!-- end RGBVH well -->
 
-              <!-- RGBVH DVI-A -->
-              <span data-toggle="modal" data-target="#rgbvh_dvi-a"><button type="button" class="btn btn-default"><img src="images/Video/dvi-a_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DVI-A</button></span>
-              <div id="rgbvh_dvi-a" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                  <div class="well">
-                    <h3><a href="pinouts.md#dvi">RGBVH DVI-A</a></h3>
-                    <div class="sample-image">
-                      <img src="images/Video/dvi-a_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://rubimages-liberty.netdna-ssl.com/hi-res/E-DVI_A-5BNCM_DVIend.png">
-                      <img src="images/Video/dvi-a_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.bhs4.com/07/A/07A6C8140CC3555552F53D6859963A86DC347FE2_large.jpg">
-                    </div>
-                    <p>Much more frequently found in its DVI-I and DVI-D flavors, Digital Video Interface (DVI) is designed to transmit uncompressed digital video information, but can be compatible with analog RGBVH video through the VGA interface. DVI-A (analog) cables and connectors are essentially the same electrically as VGA cables and connectors.</p>
-                    <p>Audio: no</p>
-                  </div>
-                </div>
-              </div>
-              </div>
-              <!-- end RGBVH DVI-A -->
-
-              <!-- RGBVH Mini-DVI -->
-              <span data-toggle="modal" data-target="#rgbvh_mini-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi_mini-DVI_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DVI</button></span>
-              <div id="rgbvh_mini-dvi" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-                <div class="modal-content">
-                  <div class="well">
-                    <h3><a href="pinouts.md#mini-dvi">RGBVH Mini-DVI</a></h3>
-                    <div class="sample-image">
-                      <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
-                      <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
-                    </div>
-                    <p>Used on certain Apple computers, especially laptops, to accept a DVI-A/VGA connection.</p>
-                    <p>Audio: no</p>
-                  </div>
-                </div>
-              </div>
-              </div>
-              <!-- end RGBVH Mini-DVI -->
-
-            </div><!-- end RGBVH well -->
-
-  </div><!-- end Analog video well -->
+</div> <!-- end Analog video well -->
 
 <!-- start Digital Video -->
-  <div class="well"><h3 id="digital_video">Digital Video</h3>
-    <p>As opposed to analog video, in digital recording the video and/or audio signal is converted into a stream of numbers (bits), that collectively represent the luminance, chrominance, and other values that make up the image. The stream must be converted back into analog waveforms to be viewed on a monitor/video screen. Provided electrical noise is not too great, it will theoretically not affect the quantification of the signal. Different standards for digital video and audio have developed in order to make it possible to pass more information along one connection in the same (or shorter) amount of time (also to make it possible to send audio information along the same cable/connection as video).</p>
+<div class="well">
+  <h3 id="digital_video">Digital Video</h3>
+  <p>As opposed to analog video, in digital recording the video and/or audio signal is converted into a stream of numbers (bits), that collectively represent the luminance, chrominance, and other values that make up the image. The stream must be converted back into analog waveforms to be viewed on a monitor/video screen. Provided electrical noise is not too great, it will theoretically not affect the quantification of the signal. Different standards for digital video and audio have developed in order to make it possible to pass more information along one connection in the same (or shorter) amount of time (also to make it possible to send audio information along the same cable/connection as video).</p>
 
-    <!-- start SDI protocol cables -->
-    <div class="well"><h4 id="sdi">SDI</h4>
-      <p>Serial Digital Interface (SDI) actually refers to a family of SMPTE interface standards designed for the transmission of uncompressed, unencrypted digital video signals. The original standard ("SD-SDI"), defined for 480i and 576i standard definition video, has been periodically updated (e.g. HD-SDI, 6G-SDI) to allow for steadily increasing bit rates, frame rates, video resolutions, etc. Because SDI is an unencypted digital signal, it has generally been restricted from use in consumer equipment, and is usually found in professional, broadcast-grade production and preservation environments.</p>
-      <p><b>Introduced: </b>1989</p>
-      <p><b>Max resolution:</b> As of 2015, the 12G-SDI standard allows up to 2160p60 video at 12 Gb/s</p>
-      <p><b>Connectors:</b></p>
+<!-- start SDI protocol cables -->
+<div class="well">
+  <h4 id="sdi">SDI</h4>
+  <p>Serial Digital Interface (SDI) actually refers to a family of SMPTE interface standards designed for the transmission of uncompressed, unencrypted digital video signals. The original standard ("SD-SDI"), defined for 480i and 576i standard definition video, has been periodically updated (e.g. HD-SDI, 6G-SDI) to allow for steadily increasing bit rates, frame rates, video resolutions, etc. Because SDI is an unencypted digital signal, it has generally been restricted from use in consumer equipment, and is usually found in professional, broadcast-grade production and preservation environments.</p>
+  <p><b>Introduced: </b>1989</p>
+  <p><b>Max resolution:</b> As of 2015, the 12G-SDI standard allows up to 2160p60 video at 12 Gb/s</p>
+  <p><b>Connectors:</b></p>
 
-        <!-- SDI BNC -->
-        <span data-toggle="modal" data-target="#sdi_bnc"><button type="button" class="btn btn-default"><img src="images/Video/BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
-        <div id="sdi_bnc" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#bnc">SDI BNC</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
-              <img src="images/Video/sdi_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.crestron.com/content/publicdownloads/products/a/a-dmc-sdi.png">
-            </div>
-            <p>SDI-compatible equipment almost always employ BNC connections, especially in broadcast/production environments. Note: even though they use the same connectors, SDI coax cables using BNC are wired differently than composite/component video cables that use BNC, and the two are not interchangeable.</p>
-            <p>Audio: yes</p>
-          </div>
-          </div>
-          </div>
+<!-- SDI BNC -->
+<span data-toggle="modal" data-target="#sdi_bnc"><button type="button" class="btn btn-default"><img src="images/Video/BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
+<div id="sdi_bnc" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#bnc">SDI BNC</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
+          <img src="images/Video/sdi_bnc_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.crestron.com/content/publicdownloads/products/a/a-dmc-sdi.png">
         </div>
-      <!-- end SDI BNC -->
-
-      <!-- SDI Video Patch (MUSA) -->
-      <span data-toggle="modal" data-target="#sdi_video-patch"><button type="button" class="btn btn-default"><img src="images/Video/composite_video-patch_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Video Patch (MUSA)</button></span>
-      <div id="sdi_video-patch" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="well">
-          <h3>SDI Video Patch (MUSA)</h3>
-          <div class="sample-image">
-            <img src="images/Video/composite_video-patch_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.bhphotovideo.com/images/images2500x2500/Canare_VPC006F_Video_Patch_Cable_154113.jpg">
-            <img src="images/Video/composite_video-patch_bottle.jpg" data-toggle="tooltip" data-placement="bottom">
-          </div>
-          <p>Video patch connections can be used to transfer SDI signals through a patch bay.</p>
-          <p>Audio: yes</p>
-        </div>
-        </div>
-        </div>
+        <p>SDI-compatible equipment almost always employ BNC connections, especially in broadcast/production environments. Note: even though they use the same connectors, SDI coax cables using BNC are wired differently than composite/component video cables that use BNC, and the two are not interchangeable.</p>
+        <p>Audio: yes</p>
       </div>
-      <!-- end SDI Video Patch (MUSA) -->
+    </div>
+  </div>
+</div>
+<!-- end SDI BNC -->
 
-    </div> <!-- end SDI -->
-
-  <!--  start Firewire protocol cables -->
-    <div class="well"><h4 id="firewire_video">FireWire</h4>
-        <p>IEEE 1394, referred to as "FireWire," was developed by Apple as an interface for high-speed data transfer. However the FireWire interface was also employed by digital cameras recording to tape media with the DV (Digital Video) protocol (e.g. MiniDV, DVCAM, DVCPRO). Some camcorders were also able to directly output a DV signal to a digital video recorder or computer via a FireWire cable/interface.  When used with digital video, the FireWire interface operates at a slower data rate than in most of its data transfer applications.</p>
-        <p><b>Introduced: </b>1994</p>
-        <p><b>Max resolution:</b> Standard Definiton, 100 Mb/s</p>
-        <p><b>Connectors:</b></p>
-
-        <!-- FireWire 4-pin -->
-        <span data-toggle="modal" data-target="#firewire_4-pin"><button type="button" class="btn btn-default"><img src="images/firewire_4-pin.jpg" class="img-responsive" style="max-height:100px; width:auto;">4-pin</button></span>
-        <div id="firewire_4-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#4-pin">FireWire 4-pin</a></h3>
-            <div class="sample-image">
-              <img src="images/firewire_4-pin.jpg" data-toggle="tooltip" data-placement="bottom" title="https://static.gearslutz.com/board/imgext.php?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fc%2Fca%2FFirewire4-pin.jpg&h=d489e11c664e0701ef5ff2c3bc40ca7e">
-              <img src="images/Video/firewire_4-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://forum.notebookreview.com/attachments/firewire1-jpg.6106/">
-            </div>
-            <p>The smallest type of FireWire connector - found on DV cameras.</p>
-            <p>Audio: yes</p>
-          </div>
-          </div>
-          </div>
+<!-- SDI Video Patch (MUSA) -->
+<span data-toggle="modal" data-target="#sdi_video-patch"><button type="button" class="btn btn-default"><img src="images/Video/composite_video-patch_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Video Patch (MUSA)</button></span>
+<div id="sdi_video-patch" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>SDI Video Patch (MUSA)</h3>
+        <div class="sample-image">
+          <img src="images/Video/composite_video-patch_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.bhphotovideo.com/images/images2500x2500/Canare_VPC006F_Video_Patch_Cable_154113.jpg">
+          <img src="images/Video/composite_video-patch_bottle.jpg" data-toggle="tooltip" data-placement="bottom">
         </div>
-        <!-- end FireWire 4-pin -->
-
-    </div> <!-- end Firewire well-->
-
-
-    <!-- start DVI protocol cables -->
-    <div class="well"><h4 id="dvi">DVI</h4>
-        <p>Digital Video Interface (DVI) was designed to transmit uncompressed digital video while also supporting analog video modes (see: DVI-I, DVI-A). This broad compatibility led to widespread adoption in consumer electronics/computers. Digital-only DVI cables and interfaces were referred to as "DVI-D".</p>
-        <p><b>Introduced: </b>1999</p>
-        <p><b>Max resolution:</b> Single Link: 1920x1200, 4.95 Gb/s; Dual Link: 2560x1600, 9.90 Gb/s</p>
-        <p><b>Connectors:</b></p>
-
-        <!-- DVI-D single-link -->
-        <span data-toggle="modal" data-target="#dvi-d_single-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-d_single-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Single-Link</button></span>
-        <div id="dvi-d_single-link" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#dvi">DVI-D Single-Link</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi-d_single-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/DVIDSMMX.C.jpg">
-            </div>
-            <p>Employs a single transmitter to support 1920x1200 resolution digital video. Notably missing the 4 pins present in DVI-A and DVI-A to carry analog video signal.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
-        </div>
-        <!-- end DVI-D single-link -->
-
-        <!-- DVI-D dual-link -->
-        <span data-toggle="modal" data-target="#dvi-d_dual-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-d_dual-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Dual-Link</button></span>
-        <div id="dvi-d_dual-link" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#dvi">DVI-D Dual-Link</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi-d_dual-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/DVIDDMMTA6.C.jpg">
-              <img src="images/Video/dvi-d_dual-link_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.nikoslab.com/wp-content/uploads/2014/11/dvi_d_dual_port.jpg">
-            </div>
-            <p>The same as DVI-D Single Link connectors, except with six additional pins in the center of the connector/port to increase bandwidth and support higher resolutions.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
-        </div>
-        <!-- end DVI-D dual-link -->
-
-        <!-- DVI-D Mini-DVI -->
-        <span data-toggle="modal" data-target="#dvi-d_mini-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi_mini-DVI_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DVI</button></span>
-        <div id="dvi-d_mini-dvi" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#mini-dvi">DVI-D Mini-DVI</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
-              <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
-            </div>
-            <p>Used on some laptops, especially Apple products, to accept a DVI-D signal.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
-        </div>
-        <!-- end DVI-D Mini-DVI -->
-
-        <!-- DVI-D Micro-DVI -->
-        <span data-toggle="modal" data-target="#dvi-d_micro-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi-d_micro_dvi_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro-DVI</button></span>
-        <div id="dvi-d_micro-dvi" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>DVI-D Micro-DVI</h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi-d_micro_dvi_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/apple-micro-dvi-to-dvi-adapter.png">
-              <img src="images/Video/dvi-d_micro-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.cis.hawaii.edu/wp-content/uploads/2014/04/microdvi.jpg">
-            </div>
-            <p>Employed for a very brief time by Apple specifically on its 2008 MacBook Air line of laptops. Smaller than Mini-DVI connectors but can only accept DVI-D signals (incompatible with DVI-I or DVI-A) and almost immediately replaced by the DisplayPort standard.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
-        </div>
-        <!-- end DVI-D Micro-DVI -->
-
-    </div> <!-- end DVI well -->
-
-
-  <!-- start DisplayPort protocol cables -->
-  <div class="well"><h4 id="displayport">DisplayPort</h4>
-      <p>A digital display interface standard developed by the Video Electronics Standards Association (VESA). Can be used to carry audio and packeted data transmissions, but most frequently employed to connect video sources to display devices. The development of succeeding versions of the DisplayPort standard (from 1.0 to the latest 1.4) have allowed for increases in display resolution, data rate, color depth, etc. "Dual-Mode DisplayPort" ports and connectors (also known as DisplayPort++) are also compatible with single-link DVI and HDMI output with the use of adapters; active converters are also available to make DisplayPort compatible with dual-link DVI or DVI-A/VGA signals.</p>
-      <p><b>Introduced: </b>2008</p>
-      <p><b>Max resolution:</b> v1.0/1.1: 1.62 Gb/s; v1.2: 2.7 Gb/s; v1.3: 8K UHD, 5.4 Gb/s; v1.4: 8K UHD, 8.1 Gb/s</p>
-      <p><b>Connectors:</b></p>
-
-      <!-- DisplayPort 20-pin -->
-      <span data-toggle="modal" data-target="#displayport_20-pin"><button type="button" class="btn btn-default"><img src="images/Video/displayport_20-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">20-pin (Full)</button></span>
-      <div id="displayport_20-pin" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#displayport">DisplayPort 20-pin (Full)</a></h3>
-          <div class="sample-image">
-            <img src="images/Video/displayport_20-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/a/a6/Displayport-cable.jpg">
-            <img src="images/Video/displayport_20-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://farm4.static.flickr.com/3642/3534308094_79c94bd454.jpg">
-          </div>
-          <p>The full-size, 20-pin DisplayPort connection used for external connections on desktop computers, graphics cards, monitors, etc.</p>
-          <p>Audio: yes, optionally (use of channels for audio signal will limit bandwidth, resolution available for video)</p>
-        </div>
-        </div>
-        </div>
+        <p>Video patch connections can be used to transfer SDI signals through a patch bay.</p>
+        <p>Audio: yes</p>
       </div>
-      <!-- end DisplayPort 20-pin -->
+    </div>
+  </div>
+</div>
+<!-- end SDI Video Patch (MUSA) -->
 
-      <!-- DisplayPort Mini-DisplayPort -->
-      <span data-toggle="modal" data-target="#mini-displayport"><button type="button" class="btn btn-default"><img src="images/Video/displayport_mini-displayport_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DisplayPort</button></span>
-      <div id="mini-displayport" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#displayport">Mini-DisplayPort</a></h3>
-          <div class="sample-image">
-            <img src="images/Video/displayport_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ea/Mini_displayport.jpg">
-            <img src="images/Video/displayport_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/47/Mini_DisplayPort_on_Apple_MacBook.jpg">
-          </div>
-          <p>Miniaturized version of the DisplayPort connector developed by Apple. Used on Apple products, especially laptops, from 2008 to the present (from ~2011 on, paired with the DisplayPort-compatible Thunderbolt protocol). Licensed out to many PC manufacturers as well.</p>
-          <p>Audio: yes (if used in conjunction with an audio-capable DisplayPort or HDMI cable)</p>
+</div> <!-- end SDI -->
+
+<!--  start Firewire protocol cables -->
+<div class="well">
+  <h4 id="firewire_video">FireWire</h4>
+  <p>IEEE 1394, referred to as "FireWire," was developed by Apple as an interface for high-speed data transfer. However the FireWire interface was also employed by digital cameras recording to tape media with the DV (Digital Video) protocol (e.g. MiniDV, DVCAM, DVCPRO). Some camcorders were also able to directly output a DV signal to a digital video recorder or computer via a FireWire cable/interface.  When used with digital video, the FireWire interface operates at a slower data rate than in most of its data transfer applications.</p>
+  <p><b>Introduced: </b>1994</p>
+  <p><b>Max resolution:</b> Standard Definiton, 100 Mb/s</p>
+  <p><b>Connectors:</b></p>
+
+<!-- FireWire 4-pin -->
+<span data-toggle="modal" data-target="#firewire_4-pin"><button type="button" class="btn btn-default"><img src="images/firewire_4-pin.jpg" class="img-responsive" style="max-height:100px; width:auto;">4-pin</button></span>
+<div id="firewire_4-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#4-pin">FireWire 4-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/firewire_4-pin.jpg" data-toggle="tooltip" data-placement="bottom" title="https://static.gearslutz.com/board/imgext.php?u=http%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fc%2Fca%2FFirewire4-pin.jpg&h=d489e11c664e0701ef5ff2c3bc40ca7e">
+          <img src="images/Video/firewire_4-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://forum.notebookreview.com/attachments/firewire1-jpg.6106/">
         </div>
-        </div>
-        </div>
+        <p>The smallest type of FireWire connector - found on DV cameras.</p>
+        <p>Audio: yes</p>
       </div>
-      <!-- end DisplayPort Mini-DisplayPort -->
+    </div>
+  </div>
+</div>
+<!-- end FireWire 4-pin -->
 
-  </div> <!-- end DisplayPort well -->
+</div> <!-- end Firewire well-->
 
+<!-- start DVI protocol cables -->
+<div class="well">
+  <h4 id="dvi">DVI</h4>
+  <p>Digital Video Interface (DVI) was designed to transmit uncompressed digital video while also supporting analog video modes (see: DVI-I, DVI-A). This broad compatibility led to widespread adoption in consumer electronics/computers. Digital-only DVI cables and interfaces were referred to as "DVI-D".</p>
+  <p><b>Introduced: </b>1999</p>
+  <p><b>Max resolution:</b> Single Link: 1920x1200, 4.95 Gb/s; Dual Link: 2560x1600, 9.90 Gb/s</p>
+  <p><b>Connectors:</b></p>
 
-  <!-- start HDMI protocol cables -->
-  <div class="well"><h4 id="hdmi">HDMI</h4>
-      <p>High-Definition Multimedia Interface (HDMI) is a proprietary interface for transferring uncompressed digital video and audio signals. HDMI was developed in order to provide an integrated, increased-bandwidth interface capable of carrying very high video resolutions and an audio signal while maintaining backwards compatibility with DVI. As with DisplayPort, succeeding versions (from 1.0 to current 2.0) have allowed for increases in resolution, frame rate, data rate, etc.</p>
-      <p><b>Introduced: </b>2002</p>
-      <p><b>Max resolution:</b> v1.0/1.1/1.2: 1920x1200p, 4.95 Gb/s; v1.3/1.4: 2560x1600p, 10.2 Gb/s; v2.0: 4096x1600p, 18 Gb/s</p>
-      <p><b>Connectors:</b></p>
-
-      <!-- HDMI Type A -->
-      <span data-toggle="modal" data-target="#hdmi_type-A"><button type="button" class="btn btn-default"><img src="images/Video/hdmi_full_A_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type A</button></span>
-      <div id="hdmi_type-A" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#hdmi">HDMI Type A</a></h3>
-          <div class="sample-image">
-            <img src="images/Video/hdmi_full_A_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://classrooms.berkeley.edu/sites/default/files/images/hdmi_full.jpeg">
-            <img src="images/Video/hdmi_full_A_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.eos.ncsu.edu/e115/text/io_images/hdmi.jpg">
-          </div>
-          <p>Generally used for HDMI input/output on television/computer monitors and desktops.</p>
-          <p>Audio: yes</p>
+<!-- DVI-D single-link -->
+<span data-toggle="modal" data-target="#dvi-d_single-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-d_single-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Single-Link</button></span>
+<div id="dvi-d_single-link" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#dvi">DVI-D Single-Link</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi-d_single-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/DVIDSMMX.C.jpg">
         </div>
-        </div>
-        </div>
+        <p>Employs a single transmitter to support 1920x1200 resolution digital video. Notably missing the 4 pins present in DVI-A and DVI-A to carry analog video signal.</p>
+        <p>Audio: no</p>
       </div>
-      <!-- end HDMI Type A -->
+    </div>
+  </div>
+</div>
+<!-- end DVI-D single-link -->
 
-      <!-- HDMI Type C -->
-      <span data-toggle="modal" data-target="#hdmi_type-C"><button type="button" class="btn btn-default"><img src="images/Video/hdmi_mini_C_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type C (Mini)</button></span>
-      <div id="hdmi_type-C" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#hdmi">HDMI Type C (Mini)</a></h3>
-          <div class="sample-image">
-            <img src="images/Video/hdmi_mini_C_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://4.bp.blogspot.com/_-4V2pG048aQ/TETWXYtMcbI/AAAAAAAAA3o/NXf3avRXGjA/s1600/HDMI-MINI-HDMI-MICRO-HDMI.jpg">
-            <img src="images/Video/hdmi_mini_C_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cable-trader.co.uk/images/finder/mini-hdmi-port.jpg">
-          </div>
-          <p>Employed starting with HDMI Version 1.3 - designed for smaller, portable equipment such as laptops.</p>
-          <p>Audio: yes</p>
+<!-- DVI-D dual-link -->
+<span data-toggle="modal" data-target="#dvi-d_dual-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-d_dual-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Dual-Link</button></span>
+<div id="dvi-d_dual-link" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#dvi">DVI-D Dual-Link</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi-d_dual-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/DVIDDMMTA6.C.jpg">
+          <img src="images/Video/dvi-d_dual-link_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.nikoslab.com/wp-content/uploads/2014/11/dvi_d_dual_port.jpg">
         </div>
-        </div>
-        </div>
+        <p>The same as DVI-D Single Link connectors, except with six additional pins in the center of the connector/port to increase bandwidth and support higher resolutions.</p>
+        <p>Audio: no</p>
       </div>
-      <!-- end HDMI Type C -->
+    </div>
+  </div>
+</div>
+<!-- end DVI-D dual-link -->
 
-      <!-- HDMI Type D -->
-      <span data-toggle="modal" data-target="#hdmi_type-D"><button type="button" class="btn btn-default"><img src="images/Video/hdmi_mini_C_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type D (Micro)</button></span>
-      <div id="hdmi_type-D" class="modal fade" tabindex="-1" role="dialog">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="well">
-          <h3><a href="pinouts.md#hdmi">HDMI Type D (Micro)</a></h3>
-          <div class="sample-image">
-            <img src="images/Video/hdmi_mini_C_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://4.bp.blogspot.com/_-4V2pG048aQ/TETWXYtMcbI/AAAAAAAAA3o/NXf3avRXGjA/s1600/HDMI-MINI-HDMI-MICRO-HDMI.jpg">
-            <img src="images/Video/hdmi_micro_D_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cnet2.cbsistatic.com/hub/i/2011/05/09/e8365dde-fdc7-11e2-8c7c-d4ae52e62bcc/4e7eb083d9859813fa3d698b38bfc09b/Android-HDMI-Phone-port.jpg">
-          </div>
-          <p>Released starting with HDMI Version 1.4, intended for use with cell phones/smart phones.</p>
-          <p>Audio: yes</p>
+<!-- DVI-D Mini-DVI -->
+<span data-toggle="modal" data-target="#dvi-d_mini-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi_mini-DVI_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DVI</button></span>
+<div id="dvi-d_mini-dvi" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#mini-dvi">DVI-D Mini-DVI</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
+          <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
         </div>
-        </div>
-        </div>
+        <p>Used on some laptops, especially Apple products, to accept a DVI-D signal.</p>
+        <p>Audio: no</p>
       </div>
-      <!-- end HMDI Type D -->
+    </div>
+  </div>
+</div>
+<!-- end DVI-D Mini-DVI -->
 
-  </div> <!-- end HDMI well -->
-
-  </div> <!-- end Digital Video well -->
-
-  <!-- start Integrated Video -->
-    <div class="well"><h3 id="integrated_video">Integrated Video</h3>
-      <p>There is no such thing as a signal that combines analog and digital data in the same channel. However, The DVI interface allows for both analog and digital signals to be passed through the same cable and connector, creating something of a unique case.</p>
-
-      <!-- start DVI-I protocol cables -->
-      <div class="well"><h4 id="dvi-i">DVI-I</h4>
-        <p>The DVI protocol is backwards-compatible to allow for the transmission of analog RGBVH data via the VGA standard. The cable is the same as that employed by DVI-A (analog-only) or DVI-D (digital only), the difference with DVI-I is merely in the compatible connectors and ports.</p>
-        <p><b>Connectors:</b></p>
-
-        <!-- DVI-I Single-Link -->
-        <span data-toggle="modal" data-target="#dvi-i_single-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-i_single-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Single-Link</button></span>
-        <div id="dvi-i_single-link" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#dvi">DVI-I Single-Link</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi-i_single-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.yourcablestore.com/assets/images/guides/plug_dvi-i_single.gif">
-            </div>
-            <p>Contains pins that allow for an analog VGA signal or digital video at up to 1920x1200 resolution.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
+<!-- DVI-D Micro-DVI -->
+<span data-toggle="modal" data-target="#dvi-d_micro-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi-d_micro_dvi_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro-DVI</button></span>
+<div id="dvi-d_micro-dvi" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>DVI-D Micro-DVI</h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi-d_micro_dvi_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macbookpro/apple-micro-dvi-to-dvi-adapter.png">
+          <img src="images/Video/dvi-d_micro-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.cis.hawaii.edu/wp-content/uploads/2014/04/microdvi.jpg">
         </div>
-        <!-- end DVI-I Single-Link -->
+        <p>Employed for a very brief time by Apple specifically on its 2008 MacBook Air line of laptops. Smaller than Mini-DVI connectors but can only accept DVI-D signals (incompatible with DVI-I or DVI-A) and almost immediately replaced by the DisplayPort standard.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end DVI-D Micro-DVI -->
 
-        <!-- DVI-I Dual-Link -->
-        <span data-toggle="modal" data-target="#dvi-i_dual-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-i_dual-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Dual-Link</button></span>
-        <div id="dvi-i_dual-link" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#dvi">DVI-I Dual-Link</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi-i_dual-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.cablemagic.com.au/media/catalog/product/cache/1/image/5e06319eda06f020e43594a9c230972d/d/v/dviidual352_1.jpg">
-              <img src="images/Video/dvi-i_dual-link_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/2904-4.jpg">
-            </div>
-            <p>The same as Single-Link DVI-I, but adds six pins in the middle of the connector for increased digital video resolution up to 2560x1600.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
+</div> <!-- end DVI well -->
+
+<!-- start DisplayPort protocol cables -->
+<div class="well">
+  <h4 id="displayport">DisplayPort</h4>
+  <p>A digital display interface standard developed by the Video Electronics Standards Association (VESA). Can be used to carry audio and packeted data transmissions, but most frequently employed to connect video sources to display devices. The development of succeeding versions of the DisplayPort standard (from 1.0 to the latest 1.4) have allowed for increases in display resolution, data rate, color depth, etc. "Dual-Mode DisplayPort" ports and connectors (also known as DisplayPort++) are also compatible with single-link DVI and HDMI output with the use of adapters; active converters are also available to make DisplayPort compatible with dual-link DVI or DVI-A/VGA signals.</p>
+  <p><b>Introduced: </b>2008</p>
+  <p><b>Max resolution:</b> v1.0/1.1: 1.62 Gb/s; v1.2: 2.7 Gb/s; v1.3: 8K UHD, 5.4 Gb/s; v1.4: 8K UHD, 8.1 Gb/s</p>
+  <p><b>Connectors:</b></p>
+
+<!-- DisplayPort 20-pin -->
+<span data-toggle="modal" data-target="#displayport_20-pin"><button type="button" class="btn btn-default"><img src="images/Video/displayport_20-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">20-pin (Full)</button></span>
+<div id="displayport_20-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#displayport">DisplayPort 20-pin (Full)</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/displayport_20-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/a/a6/Displayport-cable.jpg">
+          <img src="images/Video/displayport_20-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://farm4.static.flickr.com/3642/3534308094_79c94bd454.jpg">
         </div>
-        <!-- end DVI-I Dual-Link -->
+        <p>The full-size, 20-pin DisplayPort connection used for external connections on desktop computers, graphics cards, monitors, etc.</p>
+        <p>Audio: yes, optionally (use of channels for audio signal will limit bandwidth, resolution available for video)</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end DisplayPort 20-pin -->
 
-        <!-- DVI-I Mini-DVI -->
-        <span data-toggle="modal" data-target="#dvi-i_mini-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi_mini-DVI_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DVI</button></span>
-        <div id="dvi-i_mini-dvi" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#mini-dvi">DVI-I Mini-DVI</a></h3>
-            <div class="sample-image">
-              <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
-              <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
-            </div>
-            <p>Can connect either an analog or digital signal to an Apple laptop, as long as the proper adapter is used in conjunction with a DVI cable with DVI-A, DVI-D or DVI-I connectors.</p>
-            <p>Audio: no</p>
-          </div>
-          </div>
-          </div>
+<!-- DisplayPort Mini-DisplayPort -->
+<span data-toggle="modal" data-target="#mini-displayport"><button type="button" class="btn btn-default"><img src="images/Video/displayport_mini-displayport_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DisplayPort</button></span>
+<div id="mini-displayport" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#displayport">Mini-DisplayPort</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/displayport_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/e/ea/Mini_displayport.jpg">
+          <img src="images/Video/displayport_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/47/Mini_DisplayPort_on_Apple_MacBook.jpg">
         </div>
-        <!-- end DVI-I Mini-DVI -->
+        <p>Miniaturized version of the DisplayPort connector developed by Apple. Used on Apple products, especially laptops, from 2008 to the present (from ~2011 on, paired with the DisplayPort-compatible Thunderbolt protocol). Licensed out to many PC manufacturers as well.</p>
+        <p>Audio: yes (if used in conjunction with an audio-capable DisplayPort or HDMI cable)</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end DisplayPort Mini-DisplayPort -->
 
-      </div> <!-- end DVI-I well -->
+</div> <!-- end DisplayPort well -->
 
-    </div> <!-- end Integrated Video well -->
+<!-- start HDMI protocol cables -->
+<div class="well">
+  <h4 id="hdmi">HDMI</h4>
+  <p>High-Definition Multimedia Interface (HDMI) is a proprietary interface for transferring uncompressed digital video and audio signals. HDMI was developed in order to provide an integrated, increased-bandwidth interface capable of carrying very high video resolutions and an audio signal while maintaining backwards compatibility with DVI. As with DisplayPort, succeeding versions (from 1.0 to current 2.0) have allowed for increases in resolution, frame rate, data rate, etc.</p>
+  <p><b>Introduced: </b>2002</p>
+  <p><b>Max resolution:</b> v1.0/1.1/1.2: 1920x1200p, 4.95 Gb/s; v1.3/1.4: 2560x1600p, 10.2 Gb/s; v2.0: 4096x1600p, 18 Gb/s</p>
+  <p><b>Connectors:</b></p>
 
-  </div><!-- end Video well -->
-
-
-  <!-- start Audio cables -->
-  <div class="well"><h2 id="audio"><u>Audio</u></h2>
-
-  <!-- start Analog Audio cables -->
-    <div class="well"><h3 id="analog_audio">Analog Audio</h3>
-      <p>Unlike analog video, analog audio signals are essentially only ever transferred over one channel (i.e. one-track monaural/"mono") or two (two-track mono, or stereo). Analog audio cables, generally speaking, thus only had to carry one channel of audio and two cables would simply be employed for recording or reproducing two-track mono or stereo (in contrast to the proliferation of standards and cables for video - composite, S-Video, RBG, etc). The most critical characteristic in regard to analog audio cabling, then (beyond connector types), regards balanced vs. unbalanced wiring, a method employed to reduce noise interference in audio cables.</p>
-
-      <!-- start Balanced Analog audio cables -->
-      <div class="well"><h4 id="balanced_analog">Balanced Analog Audio</h4>
-        <p>Balanced coaxial audio cables contain three wires: "earth" (electrical ground), "hot" (positive audio signal), and "cold" (negative audio signal). The audio signal is transferred on both the hot and cold lines, but the voltage in the cold line is inverted (i.e. signal is negative when the hot line's is positive, and vice versa). When the cable is plugged into an input, the hot and cold signals are mixed together, but the cold signal is also inverted again. This has the effect of strengthening the original, recorded audio signal (doubling the number of wires it was carried on) while also canceling out the signal of any unintentional noise in the signal picked up as the audio traveled over the cable. (Since that noise was essentially "recorded" positively on to both the hot and cold lines, flipping the polarity of the cold line at input gives you exact opposite noise signals, which cancel each other out.)</p>
-        <p>Reducing analog audio noise is an issue primarily with longer cables, or in professional/broadcast or preservation environments, where the absolute integrity of the audio signal is more highly valued than on consumer equipment.</p>
-        <p><b>Connectors:</b></p>
-
-        <!-- Balanced 1/4" TRS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-4_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4″ TRS jack (mono)</button></span>
-        <div id="1-4_trs_mono" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-ring-sleeve">Balanced 1/4″ TRS Jack (mono)</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
-            </div>
-            <p>Also known as a "phone connector" for its use for many years to patch telephone connections. TRS stands for "Tip-Ring-Sleeve", referring to the three contacts on the jack (for the three wires, earth, hot and cold, present in balanced wiring). Often found with speakers, amps, some video equipment that produces monaural audio.</p>
-          </div>
-          </div>
-          </div>
+<!-- HDMI Type A -->
+<span data-toggle="modal" data-target="#hdmi_type-A"><button type="button" class="btn btn-default"><img src="images/Video/hdmi_full_A_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type A</button></span>
+<div id="hdmi_type-A" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#hdmi">HDMI Type A</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/hdmi_full_A_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://classrooms.berkeley.edu/sites/default/files/images/hdmi_full.jpeg">
+          <img src="images/Video/hdmi_full_A_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.eos.ncsu.edu/e115/text/io_images/hdmi.jpg">
         </div>
-        <!-- end Balanced 1/4" TRS jack (mono) -->
+        <p>Generally used for HDMI input/output on television/computer monitors and desktops.</p>
+        <p>Audio: yes</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end HDMI Type A -->
 
-        <!-- Balanced 1/8" TRS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-8_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TRS "mini" jack (mono)</button></span>
-        <div id="1-8_trs_mono" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-ring-sleeve">Balanced 1/8″ TRS "Mini" Jack (mono)</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
-            </div>
-            <p>Essentially the same in design as the 1/4″ jack, just smaller. Used sometimes for balanced mono audio with computers or portable devices.</p>
-          </div>
-          </div>
-          </div>
+<!-- HDMI Type C -->
+<span data-toggle="modal" data-target="#hdmi_type-C"><button type="button" class="btn btn-default"><img src="images/Video/hdmi_mini_C_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type C (Mini)</button></span>
+<div id="hdmi_type-C" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#hdmi">HDMI Type C (Mini)</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/hdmi_mini_C_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://4.bp.blogspot.com/_-4V2pG048aQ/TETWXYtMcbI/AAAAAAAAA3o/NXf3avRXGjA/s1600/HDMI-MINI-HDMI-MICRO-HDMI.jpg">
+          <img src="images/Video/hdmi_mini_C_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cable-trader.co.uk/images/finder/mini-hdmi-port.jpg">
         </div>
-        <!-- end Balanced 1/8" TRS jack (mono) -->
+        <p>Employed starting with HDMI Version 1.3 - designed for smaller, portable equipment such as laptops.</p>
+        <p>Audio: yes</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end HDMI Type C -->
 
-        <!-- Balanced TT (Bantam) -->
-        <span data-toggle="modal" data-target="#tt_bantam"><button type="button" class="btn btn-default"><img src="images/Audio/TT_bantam_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">TT/bantam Jack</button></span>
-        <div id="tt_bantam" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-ring-sleeve">Balanced Tiny Telephone (TT)/Bantam Jack</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/TT_bantam_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/43-183_01.jpg">
-            </div>
-            <p>Tiny Telephone (TT, also sometimes called bantam) jacks are smaller than 1/4″ but larger than 1/8″ jacks (approx 4.40mm). Frequently employed with patch bays in professional audio recording and preservation environments. TT jacks are most commonly found with TRS design on balanced mono cables, but unbalanced or stereo versions are possible.</p>
-          </div>
-          </div>
-          </div>
+<!-- HDMI Type D -->
+<span data-toggle="modal" data-target="#hdmi_type-D"><button type="button" class="btn btn-default"><img src="images/Video/hdmi_mini_C_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type D (Micro)</button></span>
+<div id="hdmi_type-D" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#hdmi">HDMI Type D (Micro)</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/hdmi_mini_C_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://4.bp.blogspot.com/_-4V2pG048aQ/TETWXYtMcbI/AAAAAAAAA3o/NXf3avRXGjA/s1600/HDMI-MINI-HDMI-MICRO-HDMI.jpg">
+          <img src="images/Video/hdmi_micro_D_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cnet2.cbsistatic.com/hub/i/2011/05/09/e8365dde-fdc7-11e2-8c7c-d4ae52e62bcc/4e7eb083d9859813fa3d698b38bfc09b/Android-HDMI-Phone-port.jpg">
         </div>
-        <!-- end Balanced TT (Bantam) -->
+        <p>Released starting with HDMI Version 1.4, intended for use with cell phones/smart phones.</p>
+        <p>Audio: yes</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end HMDI Type D -->
 
-        <!-- Balanced XLR -->
-        <span data-toggle="modal" data-target="#balanced_xlr"><button type="button" class="btn btn-default"><img src="images/Audio/xlr_cork_bottle_cable.jpg" class="img-responsive" style="max-height:100px; width:auto;">XLR</button></span>
-        <div id="balanced_xlr" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#xlr">Balanced XLR</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/xlr_cork_bottle_cable.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/15/Xlr-connectors.jpg">
-              <img src="images/Audio/xlr_cork_port.jpg" data-toggle="tooltip" data-placement="bottom" title="http://jp.music-group.com/TCE/CR/StudioKonnekt48/images/main_out_xlr_large.jpg">
-              <img src="images/Audio/xlr_bottle_port.jpg" data-toggle="tooltip" data-placement="bottom" title="http://proaudioblog.co.uk/wp-content/uploads/2014/06/XLR-Input.jpg">
-            </div>
-            <p>A three-pin connector favored for long balanced cables in pro audio equipment.</p>
-          </div>
-          </div>
-          </div>
+</div> <!-- end HDMI well -->
+
+</div> <!-- end Digital Video well -->
+
+<!-- start Integrated Video -->
+<div class="well">
+  <h3 id="integrated_video">Integrated Video</h3>
+  <p>There is no such thing as a signal that combines analog and digital data in the same channel. However, The DVI interface allows for both analog and digital signals to be passed through the same cable and connector, creating something of a unique case.</p>
+
+<!-- start DVI-I protocol cables -->
+<div class="well">
+  <h4 id="dvi-i">DVI-I</h4>
+  <p>The DVI protocol is backwards-compatible to allow for the transmission of analog RGBVH data via the VGA standard. The cable is the same as that employed by DVI-A (analog-only) or DVI-D (digital only), the difference with DVI-I is merely in the compatible connectors and ports.</p>
+  <p><b>Connectors:</b></p>
+
+<!-- DVI-I Single-Link -->
+<span data-toggle="modal" data-target="#dvi-i_single-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-i_single-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Single-Link</button></span>
+<div id="dvi-i_single-link" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#dvi">DVI-I Single-Link</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi-i_single-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.yourcablestore.com/assets/images/guides/plug_dvi-i_single.gif">
         </div>
-        <!-- end Balanced XLR -->
+        <p>Contains pins that allow for an analog VGA signal or digital video at up to 1920x1200 resolution.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end DVI-I Single-Link -->
 
-        <!-- Balanced Phoenix -->
-        <span data-toggle="modal" data-target="#balanced_phoenix"><button type="button" class="btn btn-default"><img src="images/Audio/phoenix_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Phoenix</button></span>
-        <div id="balanced_phoenix" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>Balanced Phoenix</h3>
-            <div class="sample-image">
-              <img src="images/Audio/phoenix_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://q1engravers.com/images/Phoenix_Connector_block_ELC-2MKKDS%20and%203MKKDS.JPG">
-            </div>
-            <p>A modular, adaptable brand of connectors for crafting one's own multi-channel, balanced or unbalanced cables and connections. Generally used to make connections on the back end of patch bays, distribution amplifiers, etc. Available in various configurations.</p>
-          </div>
-          </div>
-          </div>
+<!-- DVI-I Dual-Link -->
+<span data-toggle="modal" data-target="#dvi-i_dual-link"><button type="button" class="btn btn-default"><img src="images/Video/dvi-i_dual-link_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Dual-Link</button></span>
+<div id="dvi-i_dual-link" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#dvi">DVI-I Dual-Link</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi-i_dual-link_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.cablemagic.com.au/media/catalog/product/cache/1/image/5e06319eda06f020e43594a9c230972d/d/v/dviidual352_1.jpg">
+          <img src="images/Video/dvi-i_dual-link_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/2904-4.jpg">
         </div>
-        <!-- end Balanced Phoenix -->
+        <p>The same as Single-Link DVI-I, but adds six pins in the middle of the connector for increased digital video resolution up to 2560x1600.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end DVI-I Dual-Link -->
 
-        <!-- Balanced EDAC/ELCO -->
-        <span data-toggle="modal" data-target="#balanced_edac-elco"><button type="button" class="btn btn-default"><img src="images/Audio/edac_elco_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">EDAC/ELCO</button></span>
-        <div id="balanced_edac-elco" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>Balanced EDAC/ELCO</h3>
-            <div class="sample-image">
-              <img src="images/Audio/edac_elco_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/47-201_01.jpg">
-            </div>
-            <p>Another brand of modular, adaptable connectors. Similar in appearance and use to Phoenix. Available in various configurations.</p>
-          </div>
-          </div>
-          </div>
+<!-- DVI-I Mini-DVI -->
+<span data-toggle="modal" data-target="#dvi-i_mini-dvi"><button type="button" class="btn btn-default"><img src="images/Video/dvi_mini-DVI_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DVI</button></span>
+<div id="dvi-i_mini-dvi" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#mini-dvi">DVI-I Mini-DVI</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/dvi_mini-DVI_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/2/25/Mini-DVI_-_male_oblique_PNr%C2%B00282.jpg">
+          <img src="images/Video/dvi_mini-dvi_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/4/4f/Kobushi-mini-dvi.jpg">
         </div>
-        <!-- end Balanced EDAC/ELCO -->
+        <p>Can connect either an analog or digital signal to an Apple laptop, as long as the proper adapter is used in conjunction with a DVI cable with DVI-A, DVI-D or DVI-I connectors.</p>
+        <p>Audio: no</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end DVI-I Mini-DVI -->
 
-      </div> <!-- end Balanced analog audio well -->
+</div> <!-- end DVI-I well -->
 
-      <!-- start Unbalanced Analog audio cables -->
-      <div class="well"><h4 id="unbalanced_analog">Unbalanced Analog Audio</h4>
-        <p>Unbalanced audio cables contain only two wires for any one audio channel: "earth" (electrical ground) and "hot" (the audio signal). These are employed with short cables, internal cables or components (inside sound equipment), or consumer-grade equipment where noise is considered less of an issue.</p>
-        <p><b>Connectors:</b></p>
+</div> <!-- end Integrated Video well -->
 
-        <!-- Unbalanced RCA -->
-        <span data-toggle="modal" data-target="#unbalanced_rca"><button type="button" class="btn btn-default"><img src="images/Audio/audio_rca_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
-        <div id="unbalanced_rca" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#rca">Unbalanced RCA</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/audio_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://resource.supercheats.com/library/300w/xbox-360/xbox-hdmi-audio7.jpg">
-              <img src="images/Audio/audio_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn9.digitaltrends.com/image/nuforce-s3_bt-bluetooth-bookshelf-speakers-right-channel-rear-audio-input-macro-1500x991.jpg">
-            </div>
-            <p>By nature unbalanced connectors as they only have one pin/contact point. Frequently used for the two-channel (left and right) audio output of video decks, especially consumer-grade equipment (in such cases, often color-coded white and red, where white&nbsp;=&nbsp;channel&nbsp;1/left, red&nbsp;=&nbsp;channel 2/right).</p>
-          </div>
-          </div>
-          </div>
+</div><!-- end Video well -->
+
+<!-- start Audio cables -->
+<div class="well"><h2 id="audio"><u>Audio</u></h2>
+
+<!-- start Analog Audio cables -->
+<div class="well">
+  <h3 id="analog_audio">Analog Audio</h3>
+  <p>Unlike analog video, analog audio signals are essentially only ever transferred over one channel (i.e. one-track monaural/"mono") or two (two-track mono, or stereo). Analog audio cables, generally speaking, thus only had to carry one channel of audio and two cables would simply be employed for recording or reproducing two-track mono or stereo (in contrast to the proliferation of standards and cables for video - composite, S-Video, RBG, etc). The most critical characteristic in regard to analog audio cabling, then (beyond connector types), regards balanced vs. unbalanced wiring, a method employed to reduce noise interference in audio cables.</p>
+
+<!-- start Balanced Analog audio cables -->
+<div class="well">
+  <h4 id="balanced_analog">Balanced Analog Audio</h4>
+  <p>Balanced coaxial audio cables contain three wires: "earth" (electrical ground), "hot" (positive audio signal), and "cold" (negative audio signal). The audio signal is transferred on both the hot and cold lines, but the voltage in the cold line is inverted (i.e. signal is negative when the hot line's is positive, and vice versa). When the cable is plugged into an input, the hot and cold signals are mixed together, but the cold signal is also inverted again. This has the effect of strengthening the original, recorded audio signal (doubling the number of wires it was carried on) while also canceling out the signal of any unintentional noise in the signal picked up as the audio traveled over the cable. (Since that noise was essentially "recorded" positively on to both the hot and cold lines, flipping the polarity of the cold line at input gives you exact opposite noise signals, which cancel each other out.)</p>
+  <p>Reducing analog audio noise is an issue primarily with longer cables, or in professional/broadcast or preservation environments, where the absolute integrity of the audio signal is more highly valued than on consumer equipment.</p>
+  <p><b>Connectors:</b></p>
+
+<!-- Balanced 1/4" TRS jack (mono) -->
+<span data-toggle="modal" data-target="#1-4_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4″ TRS jack (mono)</button></span>
+<div id="1-4_trs_mono" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-ring-sleeve">Balanced 1/4″ TRS Jack (mono)</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
         </div>
-        <!-- end Unbalanced RCA -->
+        <p>Also known as a "phone connector" for its use for many years to patch telephone connections. TRS stands for "Tip-Ring-Sleeve", referring to the three contacts on the jack (for the three wires, earth, hot and cold, present in balanced wiring). Often found with speakers, amps, some video equipment that produces monaural audio.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Balanced 1/4" TRS jack (mono) -->
 
-        <!-- Unbalanced 1/4" TS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-4_TS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4" TS jack</button></span>
-        <div id="1-4_TS_jack" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-sleeve">Unbalanced 1/4″ Tip-Sleeve Jack (mono)</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/1:4-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/1-4-Mono-Plug-to-3-5mm-Mono-Jack-1.jpg">
-            </div>
-            <p>TS (Tip/Sleeve) jacks are exactly the same in appearance as balanced 1/4″ TRS jacks, except missing the "ring" contact point and cold wire. Often used for the output on musical instruments such as electric guitars.</p>
-          </div>
-          </div>
-          </div>
+<!-- Balanced 1/8" TRS jack (mono) -->
+<span data-toggle="modal" data-target="#1-8_trs_mono"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TRS "mini" jack (mono)</button></span>
+<div id="1-8_trs_mono" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-ring-sleeve">Balanced 1/8″ TRS "Mini" Jack (mono)</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
         </div>
-        <!-- end Unbalanced 1/4" TS jack (mono) -->
+        <p>Essentially the same in design as the 1/4″ jack, just smaller. Used sometimes for balanced mono audio with computers or portable devices.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Balanced 1/8" TRS jack (mono) -->
 
-        <!-- Unbalanced 1/8" TS jack (mono) -->
-        <span data-toggle="modal" data-target="#1-8_TS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TS jack</button></span>
-        <div id="1-8_TS_jack" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-sleeve">Unbalanced 1/8″ Tip-Sleeve Jack (mono)</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/1:8-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://images-na.ssl-images-amazon.com/images/G/01/musical-instruments/detail-page/B000068O47_img1.jpg">
-            </div>
-            <p>Smaller version of the unbalanced 1/4″ TS jack. Seen with [???]</p>
-          </div>
-          </div>
-          </div>
+<!-- Balanced TT (Bantam) -->
+<span data-toggle="modal" data-target="#tt_bantam"><button type="button" class="btn btn-default"><img src="images/Audio/TT_bantam_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">TT/bantam Jack</button></span>
+<div id="tt_bantam" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-ring-sleeve">Balanced Tiny Telephone (TT)/Bantam Jack</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/TT_bantam_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/43-183_01.jpg">
         </div>
-        <!-- end Unbalanced 1/8" TS jack (mono) -->
+        <p>Tiny Telephone (TT, also sometimes called bantam) jacks are smaller than 1/4″ but larger than 1/8″ jacks (approx 4.40mm). Frequently employed with patch bays in professional audio recording and preservation environments. TT jacks are most commonly found with TRS design on balanced mono cables, but unbalanced or stereo versions are possible.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Balanced TT (Bantam) -->
 
-        <!-- Unbalanced 1/4" TRS jack (stereo) -->
-        <span data-toggle="modal" data-target="#unbalanced_1-4_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4″ TRS jack (stereo)</button></span>
-        <div id="unbalanced_1-4_TRS_jack" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-ring-sleeve">Unbalanced 1/4″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
-            </div>
-            <p>By all outward appearance, the same as the 1/4″ TRS jacks used for balanced mono cables, except in the case of unbalanced stereo the three contact points are used for ground and two channels of audio, rather than ground and hot/cold versions of one audio channel. Often seen with professional headphones, and stereo microphone/monitor connections on professional video decks.</p>
-          </div>
-          </div>
-          </div>
+<!-- Balanced XLR -->
+<span data-toggle="modal" data-target="#balanced_xlr"><button type="button" class="btn btn-default"><img src="images/Audio/xlr_cork_bottle_cable.jpg" class="img-responsive" style="max-height:100px; width:auto;">XLR</button></span>
+<div id="balanced_xlr" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#xlr">Balanced XLR</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/xlr_cork_bottle_cable.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/15/Xlr-connectors.jpg">
+          <img src="images/Audio/xlr_cork_port.jpg" data-toggle="tooltip" data-placement="bottom" title="http://jp.music-group.com/TCE/CR/StudioKonnekt48/images/main_out_xlr_large.jpg">
+          <img src="images/Audio/xlr_bottle_port.jpg" data-toggle="tooltip" data-placement="bottom" title="http://proaudioblog.co.uk/wp-content/uploads/2014/06/XLR-Input.jpg">
         </div>
-        <!-- end Unbalanced 1/4" TRS jack (stereo) -->
+        <p>A three-pin connector favored for long balanced cables in pro audio equipment.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Balanced XLR -->
 
-        <!-- Unbalanced 1/8" TRS jack (stereo) -->
-        <span data-toggle="modal" data-target="#unbalanced_1-8_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TRS jack (stereo)</button></span>
-        <div id="unbalanced_1-8_TRS_jack" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#tip-ring-sleeve">Unbalanced 1/8″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
-            </div>
-            <p>See previous. Frequently used for stereo output on portable audio devices - also on computer sound cards for line-in/line-out connections (to/from headphones, microphones, speakers, etc).</p>
-          </div>
-          </div>
-          </div>
+<!-- Balanced Phoenix -->
+<span data-toggle="modal" data-target="#balanced_phoenix"><button type="button" class="btn btn-default"><img src="images/Audio/phoenix_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Phoenix</button></span>
+<div id="balanced_phoenix" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>Balanced Phoenix</h3>
+        <div class="sample-image">
+          <img src="images/Audio/phoenix_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://q1engravers.com/images/Phoenix_Connector_block_ELC-2MKKDS%20and%203MKKDS.JPG">
         </div>
-        <!-- end Unbalanced 1/8" TRS jack (stereo) -->
+        <p>A modular, adaptable brand of connectors for crafting one's own multi-channel, balanced or unbalanced cables and connections. Generally used to make connections on the back end of patch bays, distribution amplifiers, etc. Available in various configurations.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Balanced Phoenix -->
 
-        <!-- Unbalanced DIN 5-pin -->
-        <span data-toggle="modal" data-target="#unbalanced_din_5-pin"><button type="button" class="btn btn-default"><img src="images/Audio/audio_din-5-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DIN 5-pin</button></span>
-        <div id="unbalanced_din_5-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#din-5-pin">Unbalanced DIN 5-pin</a></h3>
-            <div class="sample-image">
-              <img src="images/Audio/audio_din-5-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.c2g.com/uk/static/content/images/resources/connector-guides/450/107_5_pin_din_at_m_iso.jpg">
-              <img src="images/Audio/audio_din-5-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://connector.pinoutsguide.com/photo/din5df.jpg">
-            </div>
-            <p>Similar to the purpose of the EIAJ 8-pin video monitor cable/connector, DIN 5-pins were used to carry both the audio input and output of a piece of equipment over the same cable/connection. Could carry mono or stereo signal.</p>
-          </div>
-          </div>
-          </div>
+<!-- Balanced EDAC/ELCO -->
+<span data-toggle="modal" data-target="#balanced_edac-elco"><button type="button" class="btn btn-default"><img src="images/Audio/edac_elco_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">EDAC/ELCO</button></span>
+<div id="balanced_edac-elco" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>Balanced EDAC/ELCO</h3>
+        <div class="sample-image">
+          <img src="images/Audio/edac_elco_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.canford.co.uk/Images/ItemImages/large/47-201_01.jpg">
         </div>
-        <!-- end Unbalanced DIN 5-pin -->
+        <p>Another brand of modular, adaptable connectors. Similar in appearance and use to Phoenix. Available in various configurations.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Balanced EDAC/ELCO -->
 
-      </div> <!-- end Unbalanced analog audio well -->
+</div> <!-- end Balanced analog audio well -->
 
-    </div> <!-- end Analog Audio well -->
+<!-- start Unbalanced Analog audio cables -->
+<div class="well">
+  <h4 id="unbalanced_analog">Unbalanced Analog Audio</h4>
+  <p>Unbalanced audio cables contain only two wires for any one audio channel: "earth" (electrical ground) and "hot" (the audio signal). These are employed with short cables, internal cables or components (inside sound equipment), or consumer-grade equipment where noise is considered less of an issue.</p>
+  <p><b>Connectors:</b></p>
 
-    <!-- start Digital Audio cables -->
-    <div class="well"><h3 id="digital_audio">Digital Audio</h3>
-      <p>For explanation of digital signals, see Digital Video section above.</p>
-
-      <!-- start AES-3 protocol cables -->
-      <div class="well"><h4 id="aes-3">AES-3</h4>
-          <p>AES-3 is a standard for the exchange of digital audio signals developed in conjunction by the Audio Engineering Society and the European Broadcasting Union, and is therefore also often referred to as "AES-EBU". AES-3 is capable of carrying two uncompressed channels of uncompressed PCM audio, or compressed 5.1/7.1 surround sound over the same cable.</p>
-          <p><b>Introduced: </b>1985</p>
-          <p><b>Max resolution:</b> 24-bit</p>
-          <p><b>Wiring and Connectors:</b></p>
-
-          <div class="well"><h5>Balanced</h5>
-
-            <!-- AES-3 Balanced XLR -->
-            <span data-toggle="modal" data-target="#aes-3_balanced_xlr"><button type="button" class="btn btn-default"><img src="images/Audio/xlr_cork_bottle_cable.jpg" class="img-responsive" style="max-height:100px; width:auto;">XLR</button></span>
-            <div id="aes-3_balanced_xlr" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3><a href="pinouts.md#xlr">AES-3 XLR</a></h3>
-                <div class="sample-image">
-                  <img src="images/Audio/xlr_cork_bottle_cable.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/15/Xlr-connectors.jpg">
-                </div>
-                <p>The most common variant of AES-3 connection, found with professional installations and equipment.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end AES-3 Balanced XLR -->
-
-          </div> <!-- end Balanced AES-3 well -->
-
-          <div class="well"><h5>Unbalanced</h5>
-
-            <!-- AES-3 Unbalanced BNC -->
-            <span data-toggle="modal" data-target="#aes-3_unbalanced_bnc"><button type="button" class="btn btn-default"><img src="images/Video/BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
-            <div id="aes-3_unbalanced_bnc" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3><a href="pinouts.md#bnc">AES-3 BNC</a></h3>
-                <div class="sample-image">
-                  <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
-                </div>
-                <p>A variant of AES-3 with lower (75-ohm vs balanced XLR's 110-ohm) electrical impedence. Sometimes found in broadcast applications as it uses the same cabling infrastructure as digital video, so it can be convenient for patch bays that employ BNC connections.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end AES-3 Unbalanced BNC -->
-
-          </div> <!-- end Unbalanced AES-3 well -->
-
-      </div> <!-- end AES-3 well -->
-
-
-      <!-- start S/PDIF protocol cables -->
-      <div class="well"><h4 id="spdif">S/PDIF</h4>
-          <p>Standing for Sony/Philips Digital Interface Format, S/PDIF refers to a consumer-grade variant of the AES-3 protocol (listed as "Type II" in the same international standard as AES-3: IEC 60958). Essentially interchangeable at the protocol level with AES-3, so devices carrying these signals can interface easily, provided the difference in physical connections and electrical level/impedence are accounted for.</p>
-          <p><b>Introduced: </b>1985</p>
-          <p><b>Max resolution:</b> 20-bit</p>
-          <p><b>Wiring and Connectors:</b></p>
-
-          <div class="well"><h5>Optical</h5>
-            <p>Fiber optic cables transmit data signals as flashes of light over flexible, transparent fibers made of glass or plastic. In audio applications, they can allow transmission at higher bandwidths without the electromagnetic interference to which metal wires are susceptible. Due to attenuation (the reduction of the intensity of the light over distance), consumer-grade optical audio cables are generally short (5-10 meters).</p>
-
-            <!-- S/PDIF Optical TOSLINK -->
-            <span data-toggle="modal" data-target="#spdif_toslink"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_toslink_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">F05/TOSLINK</button></span>
-            <div id="spdif_toslink" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3>S/PDIF F05/TOSLINK</h3>
-                <div class="sample-image">
-                  <img src="images/Audio/spdif_toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.soundsupport.biz/wp-content/uploads/2012/08/spdif-toslink1.jpg">
-                  <img src="images/Audio/spdif_toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.teac.com/content/images/universal/misc/ai-301da_w_digital-in.jpg">
-                </div>
-                <p>Also sometimes referred to as "EIAJ optical" connectors. While F05 is the technical name for the physical specification, Toshiba's specific brand name for optical cables, TOSLINK, has essentially become the name for the connector. Found with larger consumer-grade S/PDIF devices, particularly Toshiba-brand audio products.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end S/PDIF Optical TOSLINK -->
-
-            <!-- S/PDIF Optical Mini-TOSLINK -->
-            <span data-toggle="modal" data-target="#spdif_mini-toslink"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_mini-toslink_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-TOSLINK</button></span>
-            <div id="spdif_mini-toslink" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3>S/PDIF Mini-TOSLINK</h3>
-                <div class="sample-image">
-                  <img src="images/Audio/spdif_mini-toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://images.monoprice.com/productlargeimages/26711.jpg">
-                  <img src="images/Audio/spdif_mini-toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.headfonia.com/wp-content/uploads/2010/05/drdac_prime_10.jpg">
-                </div>
-                <p>A smaller version of the TOSLINK connector that is almost the same size and shape of a 1/8″ TRS stereo jack. Some combined 1/8″ stereo jack and Mini TOSLINK ports exist to accept either digital or analog audio input/output. Mini TOSLINK is generally used with smaller consumer-grade digital audio equipment (e.g. portable CD players).</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end S/PDIF Optical Mini-TOSLINK -->
-
-          </div> <!-- end S/PDIF Optical well -->
-
-          <div class="well"><h5>Unbalanced</h5>
-
-            <!-- S/PDIF Unbalanced RCA -->
-            <span data-toggle="modal" data-target="#spdif_rca"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_rca_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
-            <div id="spdif_rca" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3><a href="pinouts.md#rca">S/PDIF RCA</a></h3>
-                <div class="sample-image">
-                  <img src="images/Audio/spdif_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.cablesnmore.com/content/images/thumbs/0004559_spdif-digital-rca_450.jpeg">
-                  <img src="images/Audio/spdif_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.homestudiocorner.com/wp-content/uploads/2011/01/SPDIF.jpg">
-                </div>
-                <p>The S/PDIF protocol can also be found in consumer audio installations with two-contact RCA connectors over unbalanced coax cables. Such S/PDIF connectors are usually color-coded orange to differentiate them from analog audio and video cables that employ RCA.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end S/PDIF Unbalanced RCA -->
-
-          </div> <!-- end S/PDIF Unbalanced well -->
-
-      </div> <!-- end S/PDIF well -->
-
-
-      <!-- start MIDI protocol cables -->
-      <div class="well"><h4 id="midi">MIDI</h4>
-          <p>Short for Musical Instrument Digital Interface, a standard usually used for connecting a wide variety of musical instruments and/or computers to each other. MIDI links allow for the transmission of up to 16 channels of information at a time (although only in one direction, so separate cables are required for input/output). Technically speaking, MIDI does not actually carry digital audio - it carries event information that specifies control parameters such as pitch, notation, volume, vibrato, clock signals and other metadata to synchronize audio/musical devices with each other. MIDI is usually employed fairly exclusively in production/recording envrionments.</p>
-          <p><b>Introduced: </b>1983</p>
-          <p><b>Max resolution:</b> 31.25 kb/s</p>
-          <p><b>Wiring and Connectors:</b></p>
-
-          <div class="well"><h5>Balanced</h5>
-
-            <!-- MIDI Balanced DIN 5-pin -->
-            <span data-toggle="modal" data-target="#midi_din_5-pin"><button type="button" class="btn btn-default"><img src="images/Audio/midi_din-5-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DIN 5-pin</button></span>
-            <div id="midi_din_5-pin" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3>MIDI DIN 5-pin</h3>
-                <div class="sample-image">
-                  <img src="images/Audio/midi_din-5-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.image-tmart.com/images/C/CL036/USB-to-MIDI-Keyboard-Interface-Converter-Cable-Adapter-02.gif">
-                  <img src="images/Audio/midi_din-5-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/0/02/Midi_ports_and_cable.jpg">
-                </div>
-                <p>Though they have 5-pins, only 3 of the pins in MIDI connectors are used in typical applications: ground, and then a balanced pair of contacts.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end MIDI Balanced DIN 5-pin -->
-
-          </div> <!-- end MIDI Balanced well -->
-
-      </div> <!-- end MIDI well -->
-
-
-      <!-- start TDIF protocol cables -->
-      <div class="well"><h4 id="tdif">TDIF</h4>
-          <p>The Tascam Digital Interface Format is a proprietary protocol and connector, therefore seen exclusively with Tascam devices. It is bidirectional, allowing the transmission of up to eight channels of digital audio.</p>
-          <p><b>Introduced: </b>1993</p>
-          <p><b>Max resolution:</b> 31.25 kb/s</p>
-          <p><b>Wiring and Connectors:</b></p>
-
-          <div class="well"><h5>Unbalanced</h5>
-
-            <!-- TDIF Unbalanced DB-25 -->
-            <span data-toggle="modal" data-target="#tdif_db-25"><button type="button" class="btn btn-default"><img src="images/Audio/tdif_d-sub-25_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DB-25</button></span>
-            <div id="tdif_db-25" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3>TDIF DB-25</h3>
-                <div class="sample-image">
-                  <img src="images/Audio/tdif_d-sub-25_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://hosatech.com/wp-content/uploads/2014/03/DBK-300_RGB_856.jpg">
-                  <img src="images/Audio/tdif_d-sub-25_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.scmsinc.com/uploads/ecomm/my16-tdfronta.jpg">
-                </div>
-                <p>A D-subminiature connection with a pinout that allows for input and ouput of TDIF's eight channels of audio to be transmitted over the same cable.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end TDIF Unbalanced DB-25 -->
-
-          </div> <!-- end TDIF Unbalanced well -->
-
-      </div> <!-- end TDIF well -->
-
-
-      <!-- start ADAT protocol cables -->
-      <div class="well"><h4 id="adat">ADAT</h4>
-          <p>Originally developed by Alesis for its Digital Audio Tape products, the ADAT Lightpipe interface became popular with third party manufacturers and so became synonymous with the standard rather than specifically Alesis DAT connections. ADAT supports transmission of up to eight channels of uncompressed digital audio at up to 48 kHz and 24-bit, giving them a much higher bandwidth than similar S/PDIF optical cables. Found exclusively in optical cable variety.</p>
-          <p><b>Introduced: </b>1992</p>
-          <p><b>Max resolution:</b> 24-bit</p>
-          <p><b>Wiring and Connectors:</b></p>
-
-          <div class="well"><h5>Optical</h5>
-
-            <!-- ADAT F05/TOSLINK -->
-            <span data-toggle="modal" data-target="#adat_toslink"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_toslink_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">F05/TOSLINK</button></span>
-            <div id="adat_toslink" class="modal fade" tabindex="-1" role="dialog">
-              <div class="modal-dialog modal-lg">
-              <div class="modal-content">
-              <div class="well">
-                <h3>ADAT F05/TOSLINK</h3>
-                <div class="sample-image">
-                  <img src="images/Audio/spdif_toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.soundsupport.biz/wp-content/uploads/2012/08/spdif-toslink1.jpg">
-                  <img src="images/Audio/adat_toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.harmonycentral.com/forum/filedata/fetch?id=31138107&d=1398720428">
-                </div>
-                <p>Since they use the exact same connectors, ADAT cables and connections are visually indistinguishable from S/PDIF, though the interfaces and cables are completely incompatible at the protocol level.</p>
-              </div>
-              </div>
-              </div>
-            </div>
-            <!-- end ADAT F05 TOSLINK -->
-
-          </div> <!-- end ADAT Optical well -->
-
-      </div> <!-- end ADAT well -->
-
-    </div> <!-- end Digital Audio well -->
-
-  </div> <!-- end Audio well -->
-
-
-  <div class="well"><h2 id="data"><u>Data</u></h2>
-
-    <div class="well"><h3 id="parallel_data">Parallel Data</h3>
-      <p>Digital transmission can occur in one of two basic methods: parallel or serial communication. In parallel communication, multiple bits (usually 8 bits, otherwise known as one byte) are transferred simultaneously on separate channels within the same cable, then combined and synchronized. This can result in a faster bit rate than serial transmission, but is also significantly more expensive (since it requires far more wires to create the cable) and the synchronization timing in parallel transmission is also susceptible to distance, making it impractical for longer cables. Parallel communication was popular in the 1980s but has generally fallen out of favor in modern data transmission.</p>
-
-      <!-- start PATA protocol cables -->
-      <div class="well"><h4 id="pata">PATA</h4>
-        <p>Short for Parallel Advanced Technology Attachment, originally known simply as ATA until the later Serial ATA (SATA) standard was developed. An interface standard for the connection of storage devices, e.g. hard disk drives, floppy drives and optical drives. Given its maximum cable length of 18 inches, PATA is mostly limited to internal computer use, but it can occasionally be seen/used to connect to external drives.</p>
-        <p><b>Introduced: </b>1986</p>
-        <p><b>Max bit depth and rate: </b>16-bit; originally 16 mb/s, developed up to 133 mb/s</p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- PATA 40-pin ribbon -->
-        <span data-toggle="modal" data-target="#pata_40-pin"><button type="button" class="btn btn-default"><img src="images/Data/pata_40-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">40-pin</button></span>
-        <div id="pata_40-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>PATA 40-pin</h3>
-            <div class="sample-image">
-              <img src="images/Data/pata_40-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.tomshardware.com/us/2005/11/23/pc_interfaces_101/ide_w_cable.jpg">
-              <img src="images/Data/pata_40-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://chebgym5.ru/computer/images/ide-cable.jpg">
-            </div>
-            <p>Used with the most common 40-wire PATA ribbon cables, as well as the more rare 80-wire ribbons developed late in the PATA standard's lifespan to increase data rate.</p>
-          </div>
-          </div>
-          </div>
+<!-- Unbalanced RCA -->
+<span data-toggle="modal" data-target="#unbalanced_rca"><button type="button" class="btn btn-default"><img src="images/Audio/audio_rca_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
+<div id="unbalanced_rca" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#rca">Unbalanced RCA</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/audio_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://resource.supercheats.com/library/300w/xbox-360/xbox-hdmi-audio7.jpg">
+          <img src="images/Audio/audio_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn9.digitaltrends.com/image/nuforce-s3_bt-bluetooth-bookshelf-speakers-right-channel-rear-audio-input-macro-1500x991.jpg">
         </div>
-        <!-- end PATA 40-pin ribbon -->
+        <p>By nature unbalanced connectors as they only have one pin/contact point. Frequently used for the two-channel (left and right) audio output of video decks, especially consumer-grade equipment (in such cases, often color-coded white and red, where white&nbsp;=&nbsp;channel&nbsp;1/left, red&nbsp;=&nbsp;channel 2/right).</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Unbalanced RCA -->
 
-      </div> <!-- end PATA well -->
-
-
-      <!-- start Parallel SCSI protocol cables -->
-      <div class="well"><h4 id="parallel_scsi">Parallel SCSI</h4>
-        <p>Referred to alternately as SCSI (Small Computers Systems Interface) Parallel Interface, SPI, or, before the advent of Serial SCSI, simply SCSI (pronounced "scuzzy"). Unfortunately, Parallel SCSI is not technically a single standard, but a series of almost a dozen related interfaces with ambiguous names ("Fast SCSI", "Ultra SCSI," etc.) and variable bit depths and rates. See the link to a comparison table below. In any case, Parallel SCSI cables were used to connect peripheral devices to computers; unlike PATA, which could only connect a maximum of two devices, a single Parallel SCSI data bus could be attached to up to 8 or 16 devices. The symbol below generally marked a SCSI port on computers.</p>
-        <img src="images/Data/scsi_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Scsi_logo.svg/2000px-Scsi_logo.svg.png" style="background-color:white; max-height:100px;">
-        <p><b>Introduced: </b>1986</p>
-        <p><b>Max bit depth and rate: </b>See <a href="https://en.wikipedia.org/wiki/Parallel_SCSI#Comparison_table">comparison table</a></p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- Parallel SCSI 50-pin -->
-        <span data-toggle="modal" data-target="#scsi_50-pin"><button type="button" class="btn btn-default"><img src="images/Data/scsi_50-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">50-pin</button></span>
-        <div id="scsi_50-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>Parallel SCSI 50-pin Micro-Ribbon</h3>
-            <div class="sample-image">
-              <img src="images/Data/scsi_50-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/SCSI_CN50.jpg">
-              <img src="images/Data/scsi_50-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/1b/Scsi-1_gehaeuse.jpg">
-            </div>
-            <p>Micro ribbon or miniature ribbon connectors have a similar shielded design to the D-sub family of connectors, but used a different kind of contact known as ribbon contacts rather than pin contacts. There are various configurations that were used with Parallel SCSI but the most common variety was a 50-contact micro-ribbon connector. These connectors were often referred to by the brand name of the company that manufactured them: for instance, Amphenol-50, IDC-50, CN-50 (Centronics).</p>
-          </div>
-          </div>
-          </div>
+<!-- Unbalanced 1/4" TS jack (mono) -->
+<span data-toggle="modal" data-target="#1-4_TS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4" TS jack</button></span>
+<div id="1-4_TS_jack" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-sleeve">Unbalanced 1/4″ Tip-Sleeve Jack (mono)</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/1:4-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://s3.showmecables.com/images/catalog/product/1-4-Mono-Plug-to-3-5mm-Mono-Jack-1.jpg">
         </div>
-        <!-- end Parallel SCSI 50-pin -->
+        <p>TS (Tip/Sleeve) jacks are exactly the same in appearance as balanced 1/4″ TRS jacks, except missing the "ring" contact point and cold wire. Often used for the output on musical instruments such as electric guitars.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Unbalanced 1/4" TS jack (mono) -->
 
-        <!-- Parallel SCSI 25-pin -->
-        <span data-toggle="modal" data-target="#scsi_db-25"><button type="button" class="btn btn-default"><img src="images/Data/scsi_25-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DB-25</button></span>
-        <div id="scsi_db-25" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#parallel-scsi">Parallel SCSI DB-25</a></h3>
-            <div class="sample-image">
-              <img src="images/Data/scsi_25-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/SCSI_DB25.jpg">
-              <img src="images/Data/scsi_25-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.cs.uaf.edu/users/olawlor/public_html/ref/mac_ports/scsi_db25.jpg">
-            </div>
-            <p>A D-sub connector used by Apple for Parallel SCSI connections on their early desktop computers.</p>
-          </div>
-          </div>
-          </div>
+<!-- Unbalanced 1/8" TS jack (mono) -->
+<span data-toggle="modal" data-target="#1-8_TS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TS jack</button></span>
+<div id="1-8_TS_jack" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-sleeve">Unbalanced 1/8″ Tip-Sleeve Jack (mono)</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/1:8-TS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://images-na.ssl-images-amazon.com/images/G/01/musical-instruments/detail-page/B000068O47_img1.jpg">
         </div>
-        <!-- end Parallel SCSI 25-pin -->
+        <p>Smaller version of the unbalanced 1/4″ TS jack. Seen with [???]</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Unbalanced 1/8" TS jack (mono) -->
 
-        <!-- Parallel SCSI HDI-30 -->
-        <span data-toggle="modal" data-target="#scsi_hdi-30"><button type="button" class="btn btn-default"><img src="images/Data/scsi_hdi-30_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">HDI-30</button></span>
-        <div id="scsi_hdi-30" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>Parallel SCSI HDI-30</h3>
-            <div class="sample-image">
-              <img src="images/Data/scsi_hdi-30_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn2.goughlui.com/wp-content/uploads/2013/07/DSC_00114.jpg">
-              <img src="images/Data/scsi_hdi-30_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.libellules.ch/Img_connecteur/lib_scsi_hdi30f.jpg">
-            </div>
-            <p>A singular square-shaped pin contact connector used by Apple for Parallel SCSI connections on a few of their early laptop designs.</p>
-          </div>
-          </div>
-          </div>
+<!-- Unbalanced 1/4" TRS jack (stereo) -->
+<span data-toggle="modal" data-target="#unbalanced_1-4_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:4-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/4″ TRS jack (stereo)</button></span>
+<div id="unbalanced_1-4_TRS_jack" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-ring-sleeve">Unbalanced 1/4″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/1:4-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-tp1.mozu.com/2199-2317/cms/2317/files/42f48ea4-d4d4-4ef4-a7a0-0738d4c95ba6?max=400&_mzcb=">
         </div>
-        <!-- end Parallel SCSI HDI-30 -->
+        <p>By all outward appearance, the same as the 1/4″ TRS jacks used for balanced mono cables, except in the case of unbalanced stereo the three contact points are used for ground and two channels of audio, rather than ground and hot/cold versions of one audio channel. Often seen with professional headphones, and stereo microphone/monitor connections on professional video decks.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Unbalanced 1/4" TRS jack (stereo) -->
 
-      </div> <!-- end Parallel SCSI well -->
-
-
-      <!-- start IEEE 1284/Parallel Port protocol cables -->
-      <div class="well"><h4 id="parallel_port">IEEE 1284</h4>
-        <p>A standard for parallel communication variably, and more commonly, referred to as "parallel port", "printer port" or the "Centronics port", as it was originally developed by Centronics to facilitate communication between computers and Centronics-brand dot-matrix printers. Originally unidirectional ("send-only") for sending data from a computer to a printer, but later developed to allow for bidirectional communication, it became a popular alternative to Parallel SCSI for peripherals like floppy drives and network adapters and hard drives as it had cheaper circuitry. A symbol similar to the one below generally marked parallel/printer port connections on computers.</p>
-        <img src="images/Data/parallel_port_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://openclipart.org/image/2400px/svg_to_png/189941/Parallel-port.png" style="background-color:white; max-height:100px;">
-        <p><b>Introduced: </b>1970s</p>
-        <p><b>Max bit depth and rate: </b></p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- Parallel Port DB-25 -->
-        <span data-toggle="modal" data-target="#parallel-port_25-pin"><button type="button" class="btn btn-default"><img src="images/Data/parallel_port_25-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DB-25</button></span>
-        <div id="parallel-port_25-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#parallelprinter-port">Parallel Port DB-25</a></h3>
-            <div class="sample-image">
-              <img src="images/Data/parallel_port_25-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.alibaba.com/img/pb/487/415/275/275415487_248.jpg">
-              <img src="images/Data/parallel_port_25-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn.computerhope.com/parallel-port.jpg">
-            </div>
-            <p>A D-sub connection, usually used for the host (computer) end of a parallel port cable/connection.</p>
-          </div>
-          </div>
-          </div>
+<!-- Unbalanced 1/8" TRS jack (stereo) -->
+<span data-toggle="modal" data-target="#unbalanced_1-8_TRS_jack"><button type="button" class="btn btn-default"><img src="images/Audio/1:8-TRS_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">1/8″ TRS jack (stereo)</button></span>
+<div id="unbalanced_1-8_TRS_jack" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#tip-ring-sleeve">Unbalanced 1/8″ Tip-Ring-Sleeve Jack (stereo)</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/1:8-TRS_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/8/8b/Audio-TRS-Mini-Plug.jpg">
         </div>
-        <!-- end Parallel Port DB-25 -->
+        <p>See previous. Frequently used for stereo output on portable audio devices - also on computer sound cards for line-in/line-out connections (to/from headphones, microphones, speakers, etc).</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Unbalanced 1/8" TRS jack (stereo) -->
 
-        <!-- Parallel Port 36-pin -->
-        <span data-toggle="modal" data-target="#parallel-port_36-pin"><button type="button" class="btn btn-default"><img src="images/Data/parallel_port_36-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">36-pin</button></span>
-        <div id="parallel-port_36-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>Parallel Port 36-pin Micro-Ribbon</h3>
-            <div class="sample-image">
-              <img src="images/Data/parallel_port_36-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/d/d2/IEEE_1284_36pin_plughead.jpg">
-              <img src="images/Data/parallel_port_36-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.kenosha-reuse.com/SALEM,-WI/Commercial/Mechanical/Used/Plus-Warranty/Wasp-rp-WPRP200-thermal-receipt-printer-parallel-port-picture-1.jpg">
-            </div>
-            <p>A micro-ribbon connector developed by Centronics (also called CN-36), usually used for the printer or device connection.</p>
-          </div>
-          </div>
-          </div>
+<!-- Unbalanced DIN 5-pin -->
+<span data-toggle="modal" data-target="#unbalanced_din_5-pin"><button type="button" class="btn btn-default"><img src="images/Audio/audio_din-5-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DIN 5-pin</button></span>
+<div id="unbalanced_din_5-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#din-5-pin">Unbalanced DIN 5-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/audio_din-5-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.c2g.com/uk/static/content/images/resources/connector-guides/450/107_5_pin_din_at_m_iso.jpg">
+          <img src="images/Audio/audio_din-5-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://connector.pinoutsguide.com/photo/din5df.jpg">
         </div>
-        <!-- end Parallel Port 36-pin -->
+        <p>Similar to the purpose of the EIAJ 8-pin video monitor cable/connector, DIN 5-pins were used to carry both the audio input and output of a piece of equipment over the same cable/connection. Could carry mono or stereo signal.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Unbalanced DIN 5-pin -->
 
-      </div> <!-- end IEEE 1284 well -->
+</div> <!-- end Unbalanced analog audio well -->
 
-    </div> <!-- end Parallel Data well -->
+</div> <!-- end Analog Audio well -->
 
+<!-- start Digital Audio cables -->
+<div class="well">
+  <h3 id="digital_audio">Digital Audio</h3>
+  <p>For explanation of digital signals, see Digital Video section above.</p>
 
-    <!-- start Serial Data cables -->
-    <div class="well"><h3 id="serial_data">Serial Data</h3>
-      <p>As opposed to parallel transmission, in serial communication bits are transferred sequentially over the same wire. Bytes must be assembled and sent as a unit and then disassembled by the receiving device. Though serial data transmission was developed before parallel transmission, parallel communication reigned for much of the late 1970s-1980s as physical performance limitations originally gave parallel communication higher data rates. Improvements in cable and circuit design have since made serial transmission the far faster and preferred option.</p>
+<!-- start AES-3 protocol cables -->
+<div class="well">
+  <h4 id="aes-3">AES-3</h4>
+  <p>AES-3 is a standard for the exchange of digital audio signals developed in conjunction by the Audio Engineering Society and the European Broadcasting Union, and is therefore also often referred to as "AES-EBU". AES-3 is capable of carrying two uncompressed channels of uncompressed PCM audio, or compressed 5.1/7.1 surround sound over the same cable.</p>
+  <p><b>Introduced: </b>1985</p>
+  <p><b>Max resolution:</b> 24-bit</p>
+  <p><b>Wiring and Connectors:</b></p>
 
-      <!-- start RS-232 protocol cables -->
-      <div class="well"><h4 id="rs-232">RS-232</h4>
-        <p>Because it was the first serial data protocol to become a standard feature in personal computing, RS-232 was commonly referred to simply as "the serial port". It was used for bidirectional connection to many peripheral computer devices, including modems, printers, mice, external drives, etc. It was also used for remote connection and control of some VTRs. It is referred to as "RS" because it was originally sponsored by the Radio Sector of the Electronic Industries Association - changes in the sponsoring organization have caused the standard to be alternately referred to as EIA-232 and TIA-232. The symbol below generally marked serial port connections on computers.</p>
-        <img src="images/Data/serial_port_logo.png" data-toggle="tooltip" data-placement="bottom" title="http://cliparts.co/cliparts/Big/E86/BigE86ErT.png" style="background-color:white; max-height:100px;">
-        <p><b>Introduced: </b>1962</p>
-        <p><b>Max bit depth and rate: </b></p>
-        <p><b>Connectors and ports:</b></p>
+<div class="well">
+  <h5>Balanced</h5>
 
-        <!-- RS-232 DB-25 -->
-        <span data-toggle="modal" data-target="#rs-232_db-25"><button type="button" class="btn btn-default">DB-25</button></span>
-        <div id="rs-232_db-25" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>RS-232 DB-25</h3>
-            <p>The RS-232 standard recommends a 25-pin D-sub connector but did not make it mandatory - therefore it is by far the most common type of connector for both host computers and peripherals but not exclusive.</p>
-          </div>
-          </div>
-          </div>
+<!-- AES-3 Balanced XLR -->
+<span data-toggle="modal" data-target="#aes-3_balanced_xlr"><button type="button" class="btn btn-default"><img src="images/Audio/xlr_cork_bottle_cable.jpg" class="img-responsive" style="max-height:100px; width:auto;">XLR</button></span>
+<div id="aes-3_balanced_xlr" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#xlr">AES-3 XLR</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/xlr_cork_bottle_cable.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/15/Xlr-connectors.jpg">
         </div>
-        <!-- end RS-232 DB-25 -->
+        <p>The most common variant of AES-3 connection, found with professional installations and equipment.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end AES-3 Balanced XLR -->
 
-        <!-- RS-232 DB-15 -->
-        <span data-toggle="modal" data-target="#rs-232_db-15"><button type="button" class="btn btn-default">DB-15</button></span>
-        <div id="rs-232_db-15" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#db-15">RS-232 DB-15</a></h3>
-            <p>Found with RS-232 connections on some modems (on the modem end).</p>
-          </div>
-          </div>
-          </div>
+</div> <!-- end Balanced AES-3 well -->
+
+<div class="well">
+  <h5>Unbalanced</h5>
+
+<!-- AES-3 Unbalanced BNC -->
+<span data-toggle="modal" data-target="#aes-3_unbalanced_bnc"><button type="button" class="btn btn-default"><img src="images/Video/BNC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">BNC</button></span>
+<div id="aes-3_unbalanced_bnc" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#bnc">AES-3 BNC</a></h3>
+        <div class="sample-image">
+          <img src="images/Video/BNC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blog.dvrunlimited.com/wp-content/uploads/2013/09/BNC_connector_male.jpg">
         </div>
-        <!-- end RS-232 DB-15 -->
+        <p>A variant of AES-3 with lower (75-ohm vs balanced XLR's 110-ohm) electrical impedence. Sometimes found in broadcast applications as it uses the same cabling infrastructure as digital video, so it can be convenient for patch bays that employ BNC connections.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end AES-3 Unbalanced BNC -->
 
-        <!-- RS-232 DB-9 -->
-        <span data-toggle="modal" data-target="#rs-232_db-9"><button type="button" class="btn btn-default">DB-9</button></span>
-        <div id="rs-232_db-9" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>RS-232 DB-9</h3>
-            <p>Found with RS-232 connections with some modems, printers, peripherals (on the host computer end).</p>
-          </div>
-          </div>
-          </div>
+</div> <!-- end Unbalanced AES-3 well -->
+
+</div> <!-- end AES-3 well -->
+
+<!-- start S/PDIF protocol cables -->
+<div class="well">
+  <h4 id="spdif">S/PDIF</h4>
+  <p>Standing for Sony/Philips Digital Interface Format, S/PDIF refers to a consumer-grade variant of the AES-3 protocol (listed as "Type II" in the same international standard as AES-3: IEC 60958). Essentially interchangeable at the protocol level with AES-3, so devices carrying these signals can interface easily, provided the difference in physical connections and electrical level/impedence are accounted for.</p>
+  <p><b>Introduced: </b>1985</p>
+  <p><b>Max resolution:</b> 20-bit</p>
+  <p><b>Wiring and Connectors:</b></p>
+
+<div class="well">
+  <h5>Optical</h5>
+  <p>Fiber optic cables transmit data signals as flashes of light over flexible, transparent fibers made of glass or plastic. In audio applications, they can allow transmission at higher bandwidths without the electromagnetic interference to which metal wires are susceptible. Due to attenuation (the reduction of the intensity of the light over distance), consumer-grade optical audio cables are generally short (5-10 meters).</p>
+
+<!-- S/PDIF Optical TOSLINK -->
+<span data-toggle="modal" data-target="#spdif_toslink"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_toslink_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">F05/TOSLINK</button></span>
+<div id="spdif_toslink" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>S/PDIF F05/TOSLINK</h3>
+        <div class="sample-image">
+          <img src="images/Audio/spdif_toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.soundsupport.biz/wp-content/uploads/2012/08/spdif-toslink1.jpg">
+          <img src="images/Audio/spdif_toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.teac.com/content/images/universal/misc/ai-301da_w_digital-in.jpg">
         </div>
-        <!-- end RS-232 DB-9 -->
+        <p>Also sometimes referred to as "EIAJ optical" connectors. While F05 is the technical name for the physical specification, Toshiba's specific brand name for optical cables, TOSLINK, has essentially become the name for the connector. Found with larger consumer-grade S/PDIF devices, particularly Toshiba-brand audio products.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end S/PDIF Optical TOSLINK -->
 
-        <!-- RS-232 DE-9 -->
-        <span data-toggle="modal" data-target="#rs-232_de-9"><button type="button" class="btn btn-default">DE-9</button></span>
-        <div id="rs-232_de-9" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#rs-232">RS-232 DE-9</a></h3>
-            <p>Found with RS-232 connections on early mice and keyboards.</p>
-          </div>
-          </div>
-          </div>
+<!-- S/PDIF Optical Mini-TOSLINK -->
+<span data-toggle="modal" data-target="#spdif_mini-toslink"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_mini-toslink_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-TOSLINK</button></span>
+<div id="spdif_mini-toslink" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>S/PDIF Mini-TOSLINK</h3>
+        <div class="sample-image">
+          <img src="images/Audio/spdif_mini-toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://images.monoprice.com/productlargeimages/26711.jpg">
+          <img src="images/Audio/spdif_mini-toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.headfonia.com/wp-content/uploads/2010/05/drdac_prime_10.jpg">
+         </div>
+         <p>A smaller version of the TOSLINK connector that is almost the same size and shape of a 1/8″ TRS stereo jack. Some combined 1/8″ stereo jack and Mini TOSLINK ports exist to accept either digital or analog audio input/output. Mini TOSLINK is generally used with smaller consumer-grade digital audio equipment (e.g. portable CD players).</p>
+       </div>
+     </div>
+   </div>
+</div>
+<!-- end S/PDIF Optical Mini-TOSLINK -->
+
+</div> <!-- end S/PDIF Optical well -->
+
+<div class="well"><h5>Unbalanced</h5>
+
+<!-- S/PDIF Unbalanced RCA -->
+<span data-toggle="modal" data-target="#spdif_rca"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_rca_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">RCA</button></span>
+<div id="spdif_rca" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#rca">S/PDIF RCA</a></h3>
+        <div class="sample-image">
+          <img src="images/Audio/spdif_rca_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.cablesnmore.com/content/images/thumbs/0004559_spdif-digital-rca_450.jpeg">
+          <img src="images/Audio/spdif_rca_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.homestudiocorner.com/wp-content/uploads/2011/01/SPDIF.jpg">
         </div>
-        <!-- RS-232 DE-9 -->
+        <p>The S/PDIF protocol can also be found in consumer audio installations with two-contact RCA connectors over unbalanced coax cables. Such S/PDIF connectors are usually color-coded orange to differentiate them from analog audio and video cables that employ RCA.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end S/PDIF Unbalanced RCA -->
 
-      </div> <!-- end RS-232 well -->
+</div> <!-- end S/PDIF Unbalanced well -->
 
+</div> <!-- end S/PDIF well -->
 
-      <!-- start RS-422 protocol cables -->
-      <div class="well"><h4 id="rs-422">RS-422</h4>
-        <p>An improvement to the RS-232 standard to increase transmit speeds and/or maximum cable length. Introduced differential signaling to data cabling - a technique of reducing electromagnetic noise as it is transmitted over the wires in a cable, similar to balanced cables in analog audio.</p>
-        <p><b>Introduced: </b>1996</p>
-        <p><b>Max bit depth and rate: </b>10 Mb/s</p>
-        <p><b>Connectors and ports:</b></p>
+<!-- start MIDI protocol cables -->
+<div class="well">
+  <h4 id="midi">MIDI</h4>
+  <p>Short for Musical Instrument Digital Interface, a standard usually used for connecting a wide variety of musical instruments and/or computers to each other. MIDI links allow for the transmission of up to 16 channels of information at a time (although only in one direction, so separate cables are required for input/output). Technically speaking, MIDI does not actually carry digital audio - it carries event information that specifies control parameters such as pitch, notation, volume, vibrato, clock signals and other metadata to synchronize audio/musical devices with each other. MIDI is usually employed fairly exclusively in production/recording envrionments.</p>
+  <p><b>Introduced: </b>1983</p>
+  <p><b>Max resolution:</b> 31.25 kb/s</p>
+  <p><b>Wiring and Connectors:</b></p>
 
-        <!-- RS-422 DE-9 -->
-        <span data-toggle="modal" data-target="#rs-422_de-9"><button type="button" class="btn btn-default">DE-9</button></span>
-        <div id="rs-422_de-9" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#sony-9-pin-rs-422-vtr-protocol">RS-422 DE-9</a></h3>
-            <p>Found on later VTRs, especially Sony models.</p>
-          </div>
-          </div>
-          </div>
+<div class="well">
+  <h5>Balanced</h5>
+
+<!-- MIDI Balanced DIN 5-pin -->
+<span data-toggle="modal" data-target="#midi_din_5-pin"><button type="button" class="btn btn-default"><img src="images/Audio/midi_din-5-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DIN 5-pin</button></span>
+<div id="midi_din_5-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>MIDI DIN 5-pin</h3>
+        <div class="sample-image">
+          <img src="images/Audio/midi_din-5-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.image-tmart.com/images/C/CL036/USB-to-MIDI-Keyboard-Interface-Converter-Cable-Adapter-02.gif">
+          <img src="images/Audio/midi_din-5-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/0/02/Midi_ports_and_cable.jpg">
         </div>
-        <!-- end RS-422 DE-9 -->
+        <p>Though they have 5-pins, only 3 of the pins in MIDI connectors are used in typical applications: ground, and then a balanced pair of contacts.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end MIDI Balanced DIN 5-pin -->
 
-        <!-- RS-422 Mini-DIN 8-pin -->
-        <span data-toggle="modal" data-target="#rs-422_mini-din_8-pin"><button type="button" class="btn btn-default">Mini-DIN 8-pin</button></span>
-        <div id="rs-422_mini-din_8-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#apple-rs-422">RS-422 Mini-DIN 8-pin</a></h3>
-            <p>An RS-232 compatible variant of RS-422 widely used on Macintosh hardware.</p>
-          </div>
-          </div>
-          </div>
+</div> <!-- end MIDI Balanced well -->
+
+</div> <!-- end MIDI well -->
+
+<!-- start TDIF protocol cables -->
+<div class="well">
+  <h4 id="tdif">TDIF</h4>
+  <p>The Tascam Digital Interface Format is a proprietary protocol and connector, therefore seen exclusively with Tascam devices. It is bidirectional, allowing the transmission of up to eight channels of digital audio.</p>
+  <p><b>Introduced: </b>1993</p>
+  <p><b>Max resolution:</b> 31.25 kb/s</p>
+  <p><b>Wiring and Connectors:</b></p>
+
+<div class="well">
+  <h5>Unbalanced</h5>
+
+<!-- TDIF Unbalanced DB-25 -->
+<span data-toggle="modal" data-target="#tdif_db-25"><button type="button" class="btn btn-default"><img src="images/Audio/tdif_d-sub-25_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DB-25</button></span>
+<div id="tdif_db-25" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>TDIF DB-25</h3>
+        <div class="sample-image">
+          <img src="images/Audio/tdif_d-sub-25_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://hosatech.com/wp-content/uploads/2014/03/DBK-300_RGB_856.jpg">
+          <img src="images/Audio/tdif_d-sub-25_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.scmsinc.com/uploads/ecomm/my16-tdfronta.jpg">
         </div>
-        <!-- end RS-422 Mini-DIN 8-pin -->
+        <p>A D-subminiature connection with a pinout that allows for input and ouput of TDIF's eight channels of audio to be transmitted over the same cable.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end TDIF Unbalanced DB-25 -->
 
-      </div> <!-- end RS-422 well -->
+</div> <!-- end TDIF Unbalanced well -->
 
+</div> <!-- end TDIF well -->
 
-      <!-- start Serial SCSI protocol cables -->
-      <div class="well"><h4 id="sas">Serial Attached SCSI (SAS)</h4>
-        <p>Serial Attached SCSI (SAS) replaced Parallel SCSI, using the same basic command set but replacing the transmission method from parallel to serial to improve transfer rate. Backwards compatible with SATA. Unlike Parallel SCSI, almost exclusively used in internal computer connections and very rarely found in use with peripherals.</p>
-        <p><b>Introduced: </b>2004</p>
-        <p><b>Max bit depth and rate: </b>Originally 3.0 Gb/s, now up to 12.0 Gb/s</p>
-        <p><b>Connectors and ports:</b></p>
+<!-- start ADAT protocol cables -->
+<div class="well">$
+  <h4 id="adat">ADAT</h4>
+  <p>Originally developed by Alesis for its Digital Audio Tape products, the ADAT Lightpipe interface became popular with third party manufacturers and so became synonymous with the standard rather than specifically Alesis DAT connections. ADAT supports transmission of up to eight channels of uncompressed digital audio at up to 48 kHz and 24-bit, giving them a much higher bandwidth than similar S/PDIF optical cables. Found exclusively in optical cable variety.</p>
+  <p><b>Introduced: </b>1992</p>
+  <p><b>Max resolution:</b> 24-bit</p>
+  <p><b>Wiring and Connectors:</b></p>
 
-        <!-- SAS SF-8088 (Mini-SAS) -->
-        <span data-toggle="modal" data-target="#sas_sf-8088_mini-sas"><button type="button" class="btn btn-default">SF-8088 (Mini-SAS)</button></span>
-        <div id="sas_sf-8088_mini-sas" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>SAS SF-8088 (Mini-SAS)</h3>
-            <p>Shielded 26-pin implementation of SAS.</p>
-          </div>
-          </div>
-          </div>
+<div class="well">
+  <h5>Optical</h5>
+
+<!-- ADAT F05/TOSLINK -->
+<span data-toggle="modal" data-target="#adat_toslink"><button type="button" class="btn btn-default"><img src="images/Audio/spdif_toslink_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">F05/TOSLINK</button></span>
+<div id="adat_toslink" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>ADAT F05/TOSLINK</h3>
+        <div class="sample-image">
+          <img src="images/Audio/spdif_toslink_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.soundsupport.biz/wp-content/uploads/2012/08/spdif-toslink1.jpg">
+          <img src="images/Audio/adat_toslink_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.harmonycentral.com/forum/filedata/fetch?id=31138107&d=1398720428">
         </div>
-        <!-- end SAS SF-8088 (Mini-SAS) -->
+        <p>Since they use the exact same connectors, ADAT cables and connections are visually indistinguishable from S/PDIF, though the interfaces and cables are completely incompatible at the protocol level.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end ADAT F05 TOSLINK -->
 
-        <!-- SAS SF-8470 (Infiniband) -->
-        <span data-toggle="modal" data-target="#sas_sff-8470_infiniband"><button type="button" class="btn btn-default">SFf-8470 (Infiniband)</button></span>
-        <div id="sas_sff-8470_infiniband" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>SAS SF-8470 (Infiniband)</h3>
-            <p>High-density, 34-pin external connector.</p>
-          </div>
-          </div>
-          </div>
+</div> <!-- end ADAT Optical well -->
+
+</div> <!-- end ADAT well -->
+
+</div> <!-- end Digital Audio well -->
+
+</div> <!-- end Audio well -->
+
+<div class="well">
+  <h2 id="data"><u>Data</u></h2>
+
+<div class="well">
+  <h3 id="parallel_data">Parallel Data</h3>
+  <p>Digital transmission can occur in one of two basic methods: parallel or serial communication. In parallel communication, multiple bits (usually 8 bits, otherwise known as one byte) are transferred simultaneously on separate channels within the same cable, then combined and synchronized. This can result in a faster bit rate than serial transmission, but is also significantly more expensive (since it requires far more wires to create the cable) and the synchronization timing in parallel transmission is also susceptible to distance, making it impractical for longer cables. Parallel communication was popular in the 1980s but has generally fallen out of favor in modern data transmission.</p>
+
+<!-- start PATA protocol cables -->
+<div class="well">
+  <h4 id="pata">PATA</h4>
+  <p>Short for Parallel Advanced Technology Attachment, originally known simply as ATA until the later Serial ATA (SATA) standard was developed. An interface standard for the connection of storage devices, e.g. hard disk drives, floppy drives and optical drives. Given its maximum cable length of 18 inches, PATA is mostly limited to internal computer use, but it can occasionally be seen/used to connect to external drives.</p>
+  <p><b>Introduced: </b>1986</p>
+  <p><b>Max bit depth and rate: </b>16-bit; originally 16 mb/s, developed up to 133 mb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- PATA 40-pin ribbon -->
+<span data-toggle="modal" data-target="#pata_40-pin"><button type="button" class="btn btn-default"><img src="images/Data/pata_40-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">40-pin</button></span>
+<div id="pata_40-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>PATA 40-pin</h3>
+        <div class="sample-image">
+          <img src="images/Data/pata_40-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.tomshardware.com/us/2005/11/23/pc_interfaces_101/ide_w_cable.jpg">
+          <img src="images/Data/pata_40-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://chebgym5.ru/computer/images/ide-cable.jpg">
         </div>
-        <!-- end SAS SF-8470 (Infiniband) -->
+        <p>Used with the most common 40-wire PATA ribbon cables, as well as the more rare 80-wire ribbons developed late in the PATA standard's lifespan to increase data rate.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end PATA 40-pin ribbon -->
 
-      </div> <!-- end Serial SCSI well -->
+</div> <!-- end PATA well -->
 
+<!-- start Parallel SCSI protocol cables -->
+<div class="well">
+  <h4 id="parallel_scsi">Parallel SCSI</h4>
+  <p>Referred to alternately as SCSI (Small Computers Systems Interface) Parallel Interface, SPI, or, before the advent of Serial SCSI, simply SCSI (pronounced "scuzzy"). Unfortunately, Parallel SCSI is not technically a single standard, but a series of almost a dozen related interfaces with ambiguous names ("Fast SCSI", "Ultra SCSI," etc.) and variable bit depths and rates. See the link to a comparison table below. In any case, Parallel SCSI cables were used to connect peripheral devices to computers; unlike PATA, which could only connect a maximum of two devices, a single Parallel SCSI data bus could be attached to up to 8 or 16 devices. The symbol below generally marked a SCSI port on computers.</p>
+  <img src="images/Data/scsi_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Scsi_logo.svg/2000px-Scsi_logo.svg.png" style="background-color:white; max-height:100px;">
+  <p><b>Introduced: </b>1986</p>
+  <p><b>Max bit depth and rate: </b>See <a href="https://en.wikipedia.org/wiki/Parallel_SCSI#Comparison_table">comparison table</a></p>
+  <p><b>Connectors and ports:</b></p>
 
-      <!-- start SATA protocol cables -->
-      <div class="well"><h4 id="sata">SATA</h4>
-        <p>Developed to replace Parallel ATA (PATA), Serial ATA is used to connect host bus devices to mass storage devices such as hard drives, optical drives, solid-state drives, etc. Generally found for internal connections in desktops and laptops, but used in some cases to connect to external drives as well.</p>
-        <p><b>Introduced: </b>2003</p>
-        <p><b>Max bit depth and rate: </b>Originally 1.5 Gb/s, now up to 16.0 Gb/s</p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- SATA eSATA -->
-        <span data-toggle="modal" data-target="#sata_esata"><button type="button" class="btn btn-default"><img src="images/Data/e-sata_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">eSATA</button></span>
-        <div id="sata_esata" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#esata">eSATA</a></h3>
-            <div class="sample-image">
-              <img src="images/Data/e-sata_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/USB3S2ESATA3.C.jpg">
-              <img src="images/Data/e-sata_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.thecomputercoach.net/assets/images/eSATA_port.jpg">
-            </div>
-            <p>Found exclusively with SATA connections to external drives and devices (the "e" stands for "external").</p>
-          </div>
-          </div>
-          </div>
+<!-- Parallel SCSI 50-pin -->
+<span data-toggle="modal" data-target="#scsi_50-pin"><button type="button" class="btn btn-default"><img src="images/Data/scsi_50-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">50-pin</button></span>
+<div id="scsi_50-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>Parallel SCSI 50-pin Micro-Ribbon</h3>
+        <div class="sample-image">
+          <img src="images/Data/scsi_50-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/SCSI_CN50.jpg">
+          <img src="images/Data/scsi_50-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/1b/Scsi-1_gehaeuse.jpg">
         </div>
-        <!-- end SATA eSATA -->
+        <p>Micro ribbon or miniature ribbon connectors have a similar shielded design to the D-sub family of connectors, but used a different kind of contact known as ribbon contacts rather than pin contacts. There are various configurations that were used with Parallel SCSI but the most common variety was a 50-contact micro-ribbon connector. These connectors were often referred to by the brand name of the company that manufactured them: for instance, Amphenol-50, IDC-50, CN-50 (Centronics).</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Parallel SCSI 50-pin -->
 
-      </div> <!-- end SATA well -->
-
-
-      <!-- start Apple Desktop Bus protocol cables -->
-      <div class="well"><h4 id="apple_desktop_bus">Apple Desktop Bus (ADB)</h4>
-        <p>A Macintosh-exclusive computer bus for connecting low-speed peripherals - mice, keyboards, etc. ADB connections were generally marked by the symbol below.</p>
-        <img src="images/Data/apple_desktop_bus_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/en/thumb/e/eb/ADB_Icon.svg/130px-ADB_Icon.svg.png" style="background-color:white; max-height:100px;">
-        <p><b>Introduced: </b>1986</p>
-        <p><b>Max bit depth and rate: </b>125 Kb/s</p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- ADB Mini-DIN 4-pin -->
-        <span data-toggle="modal" data-target="#adb_mini-din_4-pin"><button type="button" class="btn btn-default"><img src="images/Data/apple_desktop_bus_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DIN 4-pin</button></span>
-        <div id="adb_mini-din_4-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#apple-desktop-bus">ADB Mini-DIN 4-pin</a></h3>
-            <div class="sample-image">
-              <img src="images/Data/apple_desktop_bus_cork.jpg">
-              <img src="images/Data/apple_desktop_bus_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://ttic.uchicago.edu/~cotter/projects/aek2/images/adb.jpg">
-            </div>
-            <p>The exact same connector used for S-Video connections and the cables are interchangeable. ADB cables usually were marked by the symbol above.</p>
-          </div>
-          </div>
-          </div>
+<!-- Parallel SCSI 25-pin -->
+<span data-toggle="modal" data-target="#scsi_db-25"><button type="button" class="btn btn-default"><img src="images/Data/scsi_25-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DB-25</button></span>
+<div id="scsi_db-25" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#parallel-scsi">Parallel SCSI DB-25</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/scsi_25-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/SCSI_DB25.jpg">
+          <img src="images/Data/scsi_25-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://www.cs.uaf.edu/users/olawlor/public_html/ref/mac_ports/scsi_db25.jpg">
         </div>
-        <!-- end ADB Mini-DIN 4-pin -->
+        <p>A D-sub connector used by Apple for Parallel SCSI connections on their early desktop computers.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Parallel SCSI 25-pin -->
 
-      </div> <!-- end Apple Desktop Bus well -->
-
-
-      <!-- start PS/2 protocol cables -->
-      <div class="well"><h4 id="ps2">PS/2</h4>
-        <p>A PC-compatible low-speed computer bus for peripherals like mice, keyboards, etc. Its name comes from the IBM Personal System/2 line of computers with which it was introduced. Generally replaced older RS-232 connections employing DE-9 connectors.</p>
-        <p><b>Introduced: </b>1987</p>
-        <p><b>Max bit depth and rate: </b></p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- PS/2 Mini-DIN 6-pin -->
-        <span data-toggle="modal" data-target="#ps2_mini-din_6-pin"><button type="button" class="btn btn-default"><img src="images/Data/PS2_cork1.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DIN 6-pin</button></span>
-        <div id="ps2_mini-din_6-pin" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3><a href="pinouts.md#ps2">PS/2 Mini-DIN 6-pin</a></h3>
-            <div class="sample-image">
-              <img src="images/Data/PS2_cork1.jpg">
-              <img src="images/Data/PS2_cork2.jpg">
-              <img src="images/Data/PS2_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://11986-presscdn-0-77.pagely.netdna-cdn.com/wp-content/uploads/2014/08/ps2-ports.jpg">
-            </div>
-            <p>The only connectors used for PS/2 connections. Often color-coded: green connectors were used for mice and purple for keyboards.</p>
-          </div>
-          </div>
-          </div>
+<!-- Parallel SCSI HDI-30 -->
+<span data-toggle="modal" data-target="#scsi_hdi-30"><button type="button" class="btn btn-default"><img src="images/Data/scsi_hdi-30_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">HDI-30</button></span>
+<div id="scsi_hdi-30" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>Parallel SCSI HDI-30</h3>
+        <div class="sample-image">
+          <img src="images/Data/scsi_hdi-30_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn2.goughlui.com/wp-content/uploads/2013/07/DSC_00114.jpg">
+          <img src="images/Data/scsi_hdi-30_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.libellules.ch/Img_connecteur/lib_scsi_hdi30f.jpg">
         </div>
-        <!-- end PS/2 Mini-DIN 6-pin -->
+        <p>A singular square-shaped pin contact connector used by Apple for Parallel SCSI connections on a few of their early laptop designs.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Parallel SCSI HDI-30 -->
 
-      </div> <!-- end PS/2 well -->
+</div> <!-- end Parallel SCSI well -->
 
+<!-- start IEEE 1284/Parallel Port protocol cables -->
+<div class="well">
+  <h4 id="parallel_port">IEEE 1284</h4>
+  <p>A standard for parallel communication variably, and more commonly, referred to as "parallel port", "printer port" or the "Centronics port", as it was originally developed by Centronics to facilitate communication between computers and Centronics-brand dot-matrix printers. Originally unidirectional ("send-only") for sending data from a computer to a printer, but later developed to allow for bidirectional communication, it became a popular alternative to Parallel SCSI for peripherals like floppy drives and network adapters and hard drives as it had cheaper circuitry. A symbol similar to the one below generally marked parallel/printer port connections on computers.</p>
+  <img src="images/Data/parallel_port_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://openclipart.org/image/2400px/svg_to_png/189941/Parallel-port.png" style="background-color:white; max-height:100px;">
+  <p><b>Introduced: </b>1970s</p>
+  <p><b>Max bit depth and rate: </b></p>
+  <p><b>Connectors and ports:</b></p>
 
-      <!-- start USB protocol cables -->
-      <div class="well"><h4 id="usb">USB</h4>
-        <p>Short for Universal Serial Bus, designed to standardize connections of computer peripherals after the proliferation of connections in the 1980s and early 1990s. Used with keyboards, mice, digital cameras, external drives, network adapters, etc. Capable of supplying power to many of these devices in addition to transmitting data. Updates to the original USB 1.0 standard (1.5 Mbit/s at Low Speed, 12 Mbit/s at Full Speed) have represented major shifts in data transmission, usually with accompanied changes in physical connection, so they are elaborated on more below. All advancements in USB have been backwards-compatible (so a USB 3.0 connection can carry USB 2.0 data, etc). Ports are also usually marked by the symbol below.</p>
-        <img src="images/Data/usb_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fd/USB_Icon.svg/2000px-USB_Icon.svg.png" style="background-color:white; max-height:100px;">
-        <p><b>Introduced: </b>1996</p>
-
-        <div class="well"><h5>USB 2.0</h5>
-          <p>"High Speed"</p>
-          <p><b>Introduced: </b>2000</p>
-          <p><b>Max bit depth and rate: </b>480 Mb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- USB 2.0 Type A -->
-          <span data-toggle="modal" data-target="#usb2_type-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_typeA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type A</button></span>
-          <div id="usb2_type-a" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-20">USB 2.0 Type A</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB2_typeA_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.what-is-my-computer.com/images/usb-ports.jpg">
-              </div>
-              <p>Found with USB host controllers, i.e. computers and hubs. Uses flat pins to withstand repeated attachment and removal.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Type A -->
-
-          <!-- USB 2.0 Type B -->
-          <span data-toggle="modal" data-target="#usb2_type-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB_typeB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type B</button></span>
-          <div id="usb2_type-b" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-20">USB 2.0 Type B</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/techinfo/usb_info_type-b.jpg">
-              </div>
-              <p>An "upstream" connection intended for use on USB-compatible peripheral devices (thus, the majority of USB 2.0 connections require a Type A-to-Type B cable).</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Type B -->
-
-          <!-- USB 2.0 Mini A -->
-          <span data-toggle="modal" data-target="#usb2_mini-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_miniA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini A</button></span>
-          <div id="usb2_mini-a" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-20">USB 2.0 Mini A</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB2_miniA_cork.jpg">
-              </div>
-              <p>Designed to slim down the Type A interface for use with mobile devices; quickly deprecated by the USB Implementers Forum (which guides specification and compliance of the USB protocol), meaning only a handful of certified devices ever used Mini Type A connections.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Mini A -->
-
-          <!-- USB 2.0 Mini B 5-pin -->
-          <span data-toggle="modal" data-target="#usb2_mini-b_5-pin"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_miniB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini B 5-pin</button></span>
-          <div id="usb2_mini-b_5-pin" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-20">USB 2.0 Mini B 5-pin</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB2_miniB_cork.jpg">
-              </div>
-              <p>Designed to slim down the Type B interface for use with mobile devices (PDAs, digital cameras, etc.)</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Mini B 5-pin -->
-
-          <!-- USB 2.0 Mini B 4-pin -->
-          <span data-toggle="modal" data-target="#usb2_mini-b_4-pin"><button type="button" class="btn btn-default" style="width:150px;">Mini B 4-pin</button></span>
-          <div id="usb2_mini-b_4-pin" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3>USB 2.0 Mini B 4-pin</h3>
-              <p>An unofficial implementation of USB (never supported by the USB-IF), used with some digital cameras, particularly Kodak models.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Mini B 4-pin -->
-
-          <!-- USB 2.0 Micro A -->
-          <span data-toggle="modal" data-target="#usb2_micro-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_microA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro A</button></span>
-          <div id="usb2_micro-a" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-20">USB 2.0 Micro A</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB2_microA_cork.jpg">
-              </div>
-              <p>Used on mobile devices such as cellphones, digital cameras, GPS units, etc. Smaller than Mini Type connections and identified by white-colored receptacle with 5 pins.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Micro A -->
-
-          <!-- USB 2.0 Micro B -->
-          <span data-toggle="modal" data-target="#usb2_micro-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_microB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro B</button></span>
-          <div id="usb2_micro-b" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-20">USB 2.0 Micro B</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB2_microB_cork.jpg">
-              </div>
-              <p>Used on mobile devices such as cellphones, digital cameras, GPS units, etc. Smaller than Mini Type connections and identified by black-colored receptacle with 5 pins.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 2.0 Micro B -->
-
-        </div> <!-- end USB 2.0 well -->
-
-
-        <!-- start USB 3.0 protocol cables -->
-        <div class="well"><h5>USB 3.0</h5>
-          <p>"SuperSpeed"</p>
-          <img src="images/Data/usb3_logo.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.kurokatta.org/pix/usb-superspeed-s" style="max-height:100px;">
-          <p><b>Introduced: </b>2008</p>
-          <p><b>Max bit depth and rate: </b>5 Gb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- USB 3.0 Type A -->
-          <span data-toggle="modal" data-target="#usb3_type-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB3_typeA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type A</button></span>
-          <div id="usb3_type-a" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-30">USB 3.0 Type A</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB3_typeA_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/7/75/Connector_USB_3_IMGP6024_wp.jpg">
-                <img src="images/Data/USB3_typeA_bottle1.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn8.digitaltrends.com/image/usb-3-0-ports-625x300-c.jpg">
-                <img src="images/Data/USB3_typeA_bottle2.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.howtogeek.com/wp-content/uploads/2014/01/650x434xusb-2.0-vs-usb-3.0-blue-port.jpg.pagespeed.gp+jp+jw+pj+js+rj+rp+rw+ri+cp+md.ic.Hw2qDXl-UA.jpg">
-              </div>
-              <p>Similar in sixe, shape, appearance to USB 2.0 Type A, though it has additional pins. Typically colored blue to differentiate from USB 2.0 Type A connections.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 3.0 Type A -->
-
-          <!-- USB 3.0 Type B -->
-          <span data-toggle="modal" data-target="#usb3_type-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB3_typeB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type B</button></span>
-          <div id="usb3_type-b" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-30">USB 3.0 Type B</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB3_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/usb_3_b.jpg">
-                <img src="images/Data/USB3_typeB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://hsto.org/getpro/habr/post_images/c40/af2/062/c40af20620352d5a35b1cadb413bc739.jpg">
-              </div>
-              <p>A boxy connection similar in appearance to USB 2.0 Type B, but not physically compatible with its preceding equivalent (unlike Type A). Therefore cables with a USB 3.0 Type B connector are not compatible with devices with a USB 2.0 Type B port; however devices with a USB 3.0 Type B port <b>will</b> accept USB 2.0 Type B cables. Usually colored blue.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 3.0 Type B -->
-
-          <!-- USB 3.0 Micro B -->
-          <span data-toggle="modal" data-target="#usb3_micro-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB3_microB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro B</button></span>
-          <div id="usb3_micro-b" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-30">USB 3.0 Micro B</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB3_microB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/USB3SAUBX.C.jpg">
-                <img src="images/Data/USB3_microB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://farm6.staticflickr.com/5590/14717534619_7bf547c241_o.jpg">
-              </div>
-              <p>A connection totally unique to USB 3.0 cables and devices, incompatible with previous USB devices.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 3.0 Micro B -->
-
-        </div> <!-- end USB 3.0 well -->
-
-
-        <!-- start USB 3.1 protocol cables -->
-        <div class="well"><h5>USB 3.1</h5>
-          <p>"SuperSpeed+"</p>
-          <p><b>Introduced: </b>2013</p>
-          <p><b>Max bit depth and rate: </b>10 Gb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- USB 3.1 Type C -->
-          <span data-toggle="modal" data-target="#usb3-1_type-c"><button type="button" class="btn btn-default"><img src="images/Data/USB3-1_typeC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type C</button></span>
-          <div id="usb3-1_type-c" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-31">USB 3.1 Type C</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/USB3-1_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cnet2.cbsistatic.com/img/JplrP5OaMw-Qjju0FM-E9SJEPIs=/570x0/2015/12/07/fcf70d65-4104-465e-b017-c5af7e122527/20151203-usb-type-c-001.jpg">
-                <img src="images/Data/USB3-1_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://liliputing.com/wp-content/uploads/2015/03/macbook-type-c2.jpg">
-              </div>
-              <p>A reversible, symmetrical design capable of carrying data at 10 Gbit/s (between two USB 3.1-compatible devices), power, and built-in support for DisplayPort video and four channels of audio. Increasingly found as a charging/data port for PC laptops and Apple laptops via the Thunderbolt protocol.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end USB 3.1 Type C -->
-
-        </div> <!-- end USB 3.1 well -->
-
-      </div> <!-- end USB well -->
-
-
-
-      <!-- start FireWire protocol cables -->
-      <div class="well"><h4 id="firewire_data">FireWire</h4>
-        <p>Developed by Apple at roughly the same time as USB, for the similar purpose of consolidating connections and improving data transfer speeds. Unlike USB, FireWire does not require the use of a host controller (FireWire-compatible devices can communicate directly to each other without the use of a computer), but it was more costly to implement than USB and therefore never quite as popular. Sometimes referred to as i.Link (in Sony applications) and Lynx (Texas Instruments), as FireWire is technically just the Apple branding of the IEEE 1394 standard. Used for connections to external hard drives, as well as A/V component communication and control. Two major flavors of FireWire were introduced before Apple phased out development of the standard in favor of Thunderbolt. Ports usually represented by the symbol below.</p>
-        <img src="images/Data/firewire_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/FireWire_Logo.svg/2000px-FireWire_Logo.svg.png" style="background-color:white; max-height:100px;">
-
-        <!-- start FireWire 400 cables -->
-        <div class="well"><h5>FireWire 400</h5>
-          <p>"IEEE 1394a"</p>
-          <p><b>Introduced: </b>1995</p>
-          <p><b>Max bith depth and rate: </b>400 Mb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- FireWire 400 6-pin -->
-          <span data-toggle="modal" data-target="#firewire400_6-pin"><button type="button" class="btn btn-default"><img src="images/firewire_6-pin.jpg" class="img-responsive" style="max-height:100px; width:auto;">6-pin</button></span>
-          <div id="firewire400_6-pin" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#6-pin">FireWire 400 6-pin</a></h3>
-              <div class="sample-image">
-                <img src="images/firewire_6-pin.jpg">
-                <img src="images/Data/firewire_6-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://etc.usf.edu/te_mac/hardware/i/img_1744.jpg">
-              </div>
-              <p>Can carry DC power in addition to data; thus 6-pin connections are usually found on devices that can provide power, e.g. computers.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end FireWire 400 6-pin -->
-
-          <!-- FireWire 400 4-pin -->
-          <span data-toggle="modal" data-target="#firewire400_4-pin"><button type="button" class="btn btn-default"><img src="images/firewire_4-pin.jpg" class="img-responsive" style="max-height:100px; width:auto;">4-pin</button></span>
-          <div id="firewire400_4-pin" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#4-pin">FireWire 400 4-pin</a></h3>
-              <div class="sample-image">
-                <img src="images/firewire_4-pin.jpg">
-                <img src="images/Data/firewire_4-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.jontrosky.com/images/firewire_4_pin_port.jpg">
-              </div>
-              <p>Can only carry data, no power, thus found on peripherals and devices with their own power supply, such as DV cameras, certain external hard drives.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end FireWire 400 4-pin -->
-
-        </div> <!-- end FireWire 400 well -->
-
-        <!-- start FireWire 800 cables -->
-        <div class="well"><h5>FireWire 800</h5>
-          <p>"IEEE 1394b"</p>
-          <p><b>Introduced: </b>2002</p>
-          <p><b>Max bith depth and rate: </b>800 Mb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- FireWire 800 9-pin -->
-          <span data-toggle="modal" data-target="#firewire800_9-pin"><button type="button" class="btn btn-default"><img src="images/Data/firewire_9-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">9-pin</button></span>
-          <div id="firewire800_9-pin" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#9-pin">FireWire 800 9-pin</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/firewire_9-pin_cork.jpg">
-                <img src="images/Data/firewire_9-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-image.realsimple.com/sites/default/files/styles/rs_main_image/public/image/images/0809/firewire-800-port_300.jpg?itok=UMxZPpBw">
-              </div>
-              <p>Commonly found on Apple computers. Can be adapted to older 6-pin and 4-pin connectors, but data transfer will be limited to the old 400 Mbit/s rate.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end FireWire 800 9-pin -->
-
-        </div> <!-- end FireWire 800 well -->
-
-      </div> <!-- end FireWire well -->
-
-
-      <!-- start Thunderbolt protocol cables -->
-      <div class="well"><h4 id="thunderbolt">Thunderbolt</h4>
-        <p>Developed by Apple as a replacement for FireWire. Combines computer bus data transmission with the DisplayPort digital video interface, as well as DC power, all over one cable/connection. The first two major versions of Thunderbolt shared a physical connector and had compatible wiring/channels, but the introduction of Thunderbolt 3 has been marked by major shifts in physical interface. Ports usually labelled by the symbol below.</p>
-        <img src="images/Data/thunderbolt_logo.jpg" data-toggle="tooltip" data-placement="bottom" title="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/thunderbolt_logo.png" style="max-height:100px;">
-
-        <!-- start Thunderbolt 1 and 2 cables -->
-        <div class="well"><h5>Thunderbolt 1 and 2</h5>
-          <p><b>Introduced: </b>2011;2013</p>
-          <p><b>Max bit depth and rate: </b>10 Gb/s; 20 Gb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- Thunderbolt 1 and 2 Mini-DisplayPort -->
-          <span data-toggle="modal" data-target="#thunderbolt_mini-displayport"><button type="button" class="btn btn-default"><img src="images/Data/thunderbolt_mini-displayport_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DisplayPort</button></span>
-          <div id="thunderbolt_mini-displayport" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#displayport">Thunderbolt 1 and 2 Mini-DisplayPort</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/thunderbolt_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/TBOLTMMXMW.D.jpg">
-                <img src="images/Data/thunderbolt_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://support.seagate.com/kbimg/004528-1.jpg">
-              </div>
-              <p>The Thunderbolt protocol was designed to be compatible with the Mini-DisplayPort connections already present since 2008 on many Apple computers. Saved Apple from a major redesign for several years.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end Thunderbolt 1 and 2 Mini-DisplayPort -->
-
-        </div> <!-- end Thunderbolt 1 and 2 -->
-
-
-        <!-- start Thunderbolt 3 cables -->
-        <div class="well"><h5>Thunderbolt 3</h5>
-          <p><b>Introduced: </b>2015</p>
-          <p><b>Max bit depth and rate: </b>40 Gb/s</p>
-          <p><b>Connectors and ports:</b></p>
-
-          <!-- Thunderbolt 3 USB Type C -->
-          <span data-toggle="modal" data-target="#thunderbolt3_usb_type-c"><button type="button" class="btn btn-default"><img src="images/Data/thunderbolt_typeC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">USB Type C</button></span>
-          <div id="thunderbolt3_usb_type-c" class="modal fade" tabindex="-1" role="dialog">
-            <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-            <div class="well">
-              <h3><a href="pinouts.md#usb-31">Thunderbolt 3 USB Type C</a></h3>
-              <div class="sample-image">
-                <img src="images/Data/thunderbolt_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.flatpanelshd.com/pictures/thunderbolt3-1l.jpg">
-                <img src="images/Data/thunderbolt_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blogs.intel.com/technology/files/2015/08/Lenovo-ports.jpg">
-              </div>
-              <p>Because of its capability for transferring data, digital video/audio and power all over the same connection, Apple adapted the USB Type C connector to its Thunderbolt protocol and has started using the connection as the single port on its latest MacBook Air products.</p>
-            </div>
-            </div>
-            </div>
-          </div>
-          <!-- end Thunderbolt 3 USB Type C -->
-
-        </div> <!-- end Thunderbolt 3 -->
-
-      </div> <!-- end Thunderbolt well -->
-
-
-      <!-- start HDBaseT protocol cables -->
-      <div class="well"><h4 id="hdbaset">HDBaseT</h4>
-        <p>A standard for the transmission of uncompressed HD video, audio, power, and/or networking and Ethernet connections.</p>
-        <p><b>Introduced: </b>2010</p>
-        <p><b>Max bit depth and rate: </b>10.2 Gbit/s (100 Mbit/s Ethernet)</p>
-        <p><b>Connectors and ports:</b></p>
-
-        <!-- HDBaseT 8P8C -->
-        <span data-toggle="modal" data-target="#hdbaset_8p8c"><button type="button" class="btn btn-default">8P8C/RJ-45</button></span>
-        <div id="hdbaset_8p8c" class="modal fade" tabindex="-1" role="dialog">
-          <div class="modal-dialog modal-lg">
-          <div class="modal-content">
-          <div class="well">
-            <h3>HDBaseT 8P8C/RJ-45</h3>
-            <p>A modular connector with 8 pins/conductors. Similar to but wider than the modular connectors used for phone lines.</p>
-          </div>
-          </div>
-          </div>
+<!-- Parallel Port DB-25 -->
+<span data-toggle="modal" data-target="#parallel-port_25-pin"><button type="button" class="btn btn-default"><img src="images/Data/parallel_port_25-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">DB-25</button></span>
+<div id="parallel-port_25-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#parallelprinter-port">Parallel Port DB-25</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/parallel_port_25-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.alibaba.com/img/pb/487/415/275/275415487_248.jpg">
+          <img src="images/Data/parallel_port_25-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn.computerhope.com/parallel-port.jpg">
         </div>
-        <!-- end HDBaseT 8P8C -->
+        <p>A D-sub connection, usually used for the host (computer) end of a parallel port cable/connection.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Parallel Port DB-25 -->
 
-      </div> <!-- end HDBaseT well -->
+<!-- Parallel Port 36-pin -->
+<span data-toggle="modal" data-target="#parallel-port_36-pin"><button type="button" class="btn btn-default"><img src="images/Data/parallel_port_36-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">36-pin</button></span>
+<div id="parallel-port_36-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>Parallel Port 36-pin Micro-Ribbon</h3>
+        <div class="sample-image">
+          <img src="images/Data/parallel_port_36-pin_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/d/d2/IEEE_1284_36pin_plughead.jpg">
+          <img src="images/Data/parallel_port_36-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.kenosha-reuse.com/SALEM,-WI/Commercial/Mechanical/Used/Plus-Warranty/Wasp-rp-WPRP200-thermal-receipt-printer-parallel-port-picture-1.jpg">
+        </div>
+        <p>A micro-ribbon connector developed by Centronics (also called CN-36), usually used for the printer or device connection.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Parallel Port 36-pin -->
 
-    </div> <!-- end Serial Data well -->
+</div> <!-- end IEEE 1284 well -->
 
-  </div> <!-- end Data well -->
+</div> <!-- end Parallel Data well -->
 
+<!-- start Serial Data cables -->
+<div class="well">
+  <h3 id="serial_data">Serial Data</h3>
+  <p>As opposed to parallel transmission, in serial communication bits are transferred sequentially over the same wire. Bytes must be assembled and sent as a unit and then disassembled by the receiving device. Though serial data transmission was developed before parallel transmission, parallel communication reigned for much of the late 1970s-1980s as physical performance limitations originally gave parallel communication higher data rates. Improvements in cable and circuit design have since made serial transmission the far faster and preferred option.</p>
 
-  <!-- start Power cables -->
-  <div class="well"><h2 id="power"><u>Power</u></h2>
-    <p>From Type A to Type N, the <a href="http://www.iec.ch/worldplugs/" target="_blank">IEC website</a> provides descriptions, images, and supporting countries to plugs and sockets used around the world.</p>
+<!-- start RS-232 protocol cables -->
+<div class="well">
+  <h4 id="rs-232">RS-232</h4>
+  <p>Because it was the first serial data protocol to become a standard feature in personal computing, RS-232 was commonly referred to simply as "the serial port". It was used for bidirectional connection to many peripheral computer devices, including modems, printers, mice, external drives, etc. It was also used for remote connection and control of some VTRs. It is referred to as "RS" because it was originally sponsored by the Radio Sector of the Electronic Industries Association - changes in the sponsoring organization have caused the standard to be alternately referred to as EIA-232 and TIA-232. The symbol below generally marked serial port connections on computers.</p>
+  <img src="images/Data/serial_port_logo.png" data-toggle="tooltip" data-placement="bottom" title="http://cliparts.co/cliparts/Big/E86/BigE86ErT.png" style="background-color:white; max-height:100px;">
+  <p><b>Introduced: </b>1962</p>
+  <p><b>Max bit depth and rate: </b></p>
+  <p><b>Connectors and ports:</b></p>
 
-  </div> <!-- end Power well -->
+<!-- RS-232 DB-25 -->
+<span data-toggle="modal" data-target="#rs-232_db-25"><button type="button" class="btn btn-default">DB-25</button></span>
+<div id="rs-232_db-25" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>RS-232 DB-25</h3>
+        <p>The RS-232 standard recommends a 25-pin D-sub connector but did not make it mandatory - therefore it is by far the most common type of connector for both host computers and peripherals but not exclusive.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RS-232 DB-25 -->
+
+<!-- RS-232 DB-15 -->
+<span data-toggle="modal" data-target="#rs-232_db-15"><button type="button" class="btn btn-default">DB-15</button></span>
+<div id="rs-232_db-15" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#db-15">RS-232 DB-15</a></h3>
+        <p>Found with RS-232 connections on some modems (on the modem end).</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RS-232 DB-15 -->
+
+<!-- RS-232 DB-9 -->
+<span data-toggle="modal" data-target="#rs-232_db-9"><button type="button" class="btn btn-default">DB-9</button></span>
+<div id="rs-232_db-9" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>RS-232 DB-9</h3>
+        <p>Found with RS-232 connections with some modems, printers, peripherals (on the host computer end).</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RS-232 DB-9 -->
+
+<!-- RS-232 DE-9 -->
+<span data-toggle="modal" data-target="#rs-232_de-9"><button type="button" class="btn btn-default">DE-9</button></span>
+<div id="rs-232_de-9" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#rs-232">RS-232 DE-9</a></h3>
+        <p>Found with RS-232 connections on early mice and keyboards.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- RS-232 DE-9 -->
+
+</div> <!-- end RS-232 well -->
+
+<!-- start RS-422 protocol cables -->
+<div class="well">
+  <h4 id="rs-422">RS-422</h4>
+  <p>An improvement to the RS-232 standard to increase transmit speeds and/or maximum cable length. Introduced differential signaling to data cabling - a technique of reducing electromagnetic noise as it is transmitted over the wires in a cable, similar to balanced cables in analog audio.</p>
+  <p><b>Introduced: </b>1996</p>
+  <p><b>Max bit depth and rate: </b>10 Mb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- RS-422 DE-9 -->
+<span data-toggle="modal" data-target="#rs-422_de-9"><button type="button" class="btn btn-default">DE-9</button></span>
+<div id="rs-422_de-9" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#sony-9-pin-rs-422-vtr-protocol">RS-422 DE-9</a></h3>
+        <p>Found on later VTRs, especially Sony models.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RS-422 DE-9 -->
+
+<!-- RS-422 Mini-DIN 8-pin -->
+<span data-toggle="modal" data-target="#rs-422_mini-din_8-pin"><button type="button" class="btn btn-default">Mini-DIN 8-pin</button></span>
+<div id="rs-422_mini-din_8-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#apple-rs-422">RS-422 Mini-DIN 8-pin</a></h3>
+        <p>An RS-232 compatible variant of RS-422 widely used on Macintosh hardware.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end RS-422 Mini-DIN 8-pin -->
+
+</div> <!-- end RS-422 well -->
+
+<!-- start Serial SCSI protocol cables -->
+<div class="well">
+  <h4 id="sas">Serial Attached SCSI (SAS)</h4>
+  <p>Serial Attached SCSI (SAS) replaced Parallel SCSI, using the same basic command set but replacing the transmission method from parallel to serial to improve transfer rate. Backwards compatible with SATA. Unlike Parallel SCSI, almost exclusively used in internal computer connections and very rarely found in use with peripherals.</p>
+  <p><b>Introduced: </b>2004</p>
+  <p><b>Max bit depth and rate: </b>Originally 3.0 Gb/s, now up to 12.0 Gb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- SAS SF-8088 (Mini-SAS) -->
+<span data-toggle="modal" data-target="#sas_sf-8088_mini-sas"><button type="button" class="btn btn-default">SF-8088 (Mini-SAS)</button></span>
+<div id="sas_sf-8088_mini-sas" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>SAS SF-8088 (Mini-SAS)</h3>
+        <p>Shielded 26-pin implementation of SAS.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end SAS SF-8088 (Mini-SAS) -->
+
+<!-- SAS SF-8470 (Infiniband) -->
+<span data-toggle="modal" data-target="#sas_sff-8470_infiniband"><button type="button" class="btn btn-default">SFf-8470 (Infiniband)</button></span>
+<div id="sas_sff-8470_infiniband" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>SAS SF-8470 (Infiniband)</h3>
+        <p>High-density, 34-pin external connector.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end SAS SF-8470 (Infiniband) -->
+
+</div> <!-- end Serial SCSI well -->
+
+<!-- start SATA protocol cables -->
+<div class="well">
+  <h4 id="sata">SATA</h4>
+  <p>Developed to replace Parallel ATA (PATA), Serial ATA is used to connect host bus devices to mass storage devices such as hard drives, optical drives, solid-state drives, etc. Generally found for internal connections in desktops and laptops, but used in some cases to connect to external drives as well.</p>
+  <p><b>Introduced: </b>2003</p>
+  <p><b>Max bit depth and rate: </b>Originally 1.5 Gb/s, now up to 16.0 Gb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- SATA eSATA -->
+<span data-toggle="modal" data-target="#sata_esata"><button type="button" class="btn btn-default"><img src="images/Data/e-sata_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">eSATA</button></span>
+<div id="sata_esata" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#esata">eSATA</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/e-sata_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/USB3S2ESATA3.C.jpg">
+          <img src="images/Data/e-sata_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.thecomputercoach.net/assets/images/eSATA_port.jpg">
+        </div>
+        <p>Found exclusively with SATA connections to external drives and devices (the "e" stands for "external").</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end SATA eSATA -->
+
+</div> <!-- end SATA well -->
+
+<!-- start Apple Desktop Bus protocol cables -->
+<div class="well">
+  <h4 id="apple_desktop_bus">Apple Desktop Bus (ADB)</h4>
+  <p>A Macintosh-exclusive computer bus for connecting low-speed peripherals - mice, keyboards, etc. ADB connections were generally marked by the symbol below.</p>
+  <img src="images/Data/apple_desktop_bus_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/en/thumb/e/eb/ADB_Icon.svg/130px-ADB_Icon.svg.png" style="background-color:white; max-height:100px;">
+  <p><b>Introduced: </b>1986</p>
+  <p><b>Max bit depth and rate: </b>125 Kb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- ADB Mini-DIN 4-pin -->
+<span data-toggle="modal" data-target="#adb_mini-din_4-pin"><button type="button" class="btn btn-default"><img src="images/Data/apple_desktop_bus_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DIN 4-pin</button></span>
+<div id="adb_mini-din_4-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#apple-desktop-bus">ADB Mini-DIN 4-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/apple_desktop_bus_cork.jpg">
+          <img src="images/Data/apple_desktop_bus_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://ttic.uchicago.edu/~cotter/projects/aek2/images/adb.jpg">
+        </div>
+        <p>The exact same connector used for S-Video connections and the cables are interchangeable. ADB cables usually were marked by the symbol above.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end ADB Mini-DIN 4-pin -->
+
+</div> <!-- end Apple Desktop Bus well -->
+
+<!-- start PS/2 protocol cables -->
+<div class="well">
+  <h4 id="ps2">PS/2</h4>
+  <p>A PC-compatible low-speed computer bus for peripherals like mice, keyboards, etc. Its name comes from the IBM Personal System/2 line of computers with which it was introduced. Generally replaced older RS-232 connections employing DE-9 connectors.</p>
+  <p><b>Introduced: </b>1987</p>
+  <p><b>Max bit depth and rate: </b></p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- PS/2 Mini-DIN 6-pin -->
+<span data-toggle="modal" data-target="#ps2_mini-din_6-pin"><button type="button" class="btn btn-default"><img src="images/Data/PS2_cork1.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DIN 6-pin</button></span>
+<div id="ps2_mini-din_6-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#ps2">PS/2 Mini-DIN 6-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/PS2_cork1.jpg">
+          <img src="images/Data/PS2_cork2.jpg">
+          <img src="images/Data/PS2_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://11986-presscdn-0-77.pagely.netdna-cdn.com/wp-content/uploads/2014/08/ps2-ports.jpg">
+        </div>
+        <p>The only connectors used for PS/2 connections. Often color-coded: green connectors were used for mice and purple for keyboards.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end PS/2 Mini-DIN 6-pin -->
+
+</div> <!-- end PS/2 well -->
+
+<!-- start USB protocol cables -->
+<div class="well">
+  <h4 id="usb">USB</h4>
+  <p>Short for Universal Serial Bus, designed to standardize connections of computer peripherals after the proliferation of connections in the 1980s and early 1990s. Used with keyboards, mice, digital cameras, external drives, network adapters, etc. Capable of supplying power to many of these devices in addition to transmitting data. Updates to the original USB 1.0 standard (1.5 Mbit/s at Low Speed, 12 Mbit/s at Full Speed) have represented major shifts in data transmission, usually with accompanied changes in physical connection, so they are elaborated on more below. All advancements in USB have been backwards-compatible (so a USB 3.0 connection can carry USB 2.0 data, etc). Ports are also usually marked by the symbol below.</p>
+  <img src="images/Data/usb_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fd/USB_Icon.svg/2000px-USB_Icon.svg.png" style="background-color:white; max-height:100px;">
+  <p><b>Introduced: </b>1996</p>
+
+<div class="well">
+  <h5>USB 2.0</h5>
+  <p>"High Speed"</p>
+  <p><b>Introduced: </b>2000</p>
+  <p><b>Max bit depth and rate: </b>480 Mb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- USB 2.0 Type A -->
+<span data-toggle="modal" data-target="#usb2_type-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_typeA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type A</button></span>
+<div id="usb2_type-a" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-20">USB 2.0 Type A</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB2_typeA_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.what-is-my-computer.com/images/usb-ports.jpg">
+        </div>
+        <p>Found with USB host controllers, i.e. computers and hubs. Uses flat pins to withstand repeated attachment and removal.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Type A -->
+
+<!-- USB 2.0 Type B -->
+<span data-toggle="modal" data-target="#usb2_type-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB_typeB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type B</button></span>
+<div id="usb2_type-b" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-20">USB 2.0 Type B</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/techinfo/usb_info_type-b.jpg">
+        </div>
+        <p>An "upstream" connection intended for use on USB-compatible peripheral devices (thus, the majority of USB 2.0 connections require a Type A-to-Type B cable).</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Type B -->
+
+<!-- USB 2.0 Mini A -->
+<span data-toggle="modal" data-target="#usb2_mini-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_miniA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini A</button></span>
+<div id="usb2_mini-a" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-20">USB 2.0 Mini A</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB2_miniA_cork.jpg">
+        </div>
+        <p>Designed to slim down the Type A interface for use with mobile devices; quickly deprecated by the USB Implementers Forum (which guides specification and compliance of the USB protocol), meaning only a handful of certified devices ever used Mini Type A connections.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Mini A -->
+
+<!-- USB 2.0 Mini B 5-pin -->
+<span data-toggle="modal" data-target="#usb2_mini-b_5-pin"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_miniB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini B 5-pin</button></span>
+<div id="usb2_mini-b_5-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-20">USB 2.0 Mini B 5-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB2_miniB_cork.jpg">
+        </div>
+        <p>Designed to slim down the Type B interface for use with mobile devices (PDAs, digital cameras, etc.)</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Mini B 5-pin -->
+
+<!-- USB 2.0 Mini B 4-pin -->
+<span data-toggle="modal" data-target="#usb2_mini-b_4-pin"><button type="button" class="btn btn-default" style="width:150px;">Mini B 4-pin</button></span>
+<div id="usb2_mini-b_4-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>USB 2.0 Mini B 4-pin</h3>
+        <p>An unofficial implementation of USB (never supported by the USB-IF), used with some digital cameras, particularly Kodak models.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Mini B 4-pin -->
+
+<!-- USB 2.0 Micro A -->
+<span data-toggle="modal" data-target="#usb2_micro-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_microA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro A</button></span>
+<div id="usb2_micro-a" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-20">USB 2.0 Micro A</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB2_microA_cork.jpg">
+        </div>
+        <p>Used on mobile devices such as cellphones, digital cameras, GPS units, etc. Smaller than Mini Type connections and identified by white-colored receptacle with 5 pins.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Micro A -->
+
+<!-- USB 2.0 Micro B -->
+<span data-toggle="modal" data-target="#usb2_micro-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB2_microB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro B</button></span>
+<div id="usb2_micro-b" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-20">USB 2.0 Micro B</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB2_microB_cork.jpg">
+        </div>
+        <p>Used on mobile devices such as cellphones, digital cameras, GPS units, etc. Smaller than Mini Type connections and identified by black-colored receptacle with 5 pins.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 2.0 Micro B -->
+
+</div> <!-- end USB 2.0 well -->
+
+<!-- start USB 3.0 protocol cables -->
+<div class="well">
+  <h5>USB 3.0</h5>
+  <p>"SuperSpeed"</p>
+  <img src="images/Data/usb3_logo.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.kurokatta.org/pix/usb-superspeed-s" style="max-height:100px;">
+  <p><b>Introduced: </b>2008</p>
+  <p><b>Max bit depth and rate: </b>5 Gb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- USB 3.0 Type A -->
+<span data-toggle="modal" data-target="#usb3_type-a"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB3_typeA_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type A</button></span>
+<div id="usb3_type-a" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-30">USB 3.0 Type A</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB3_typeA_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/7/75/Connector_USB_3_IMGP6024_wp.jpg">
+          <img src="images/Data/USB3_typeA_bottle1.jpg" data-toggle="tooltip" data-placement="bottom" title="http://icdn8.digitaltrends.com/image/usb-3-0-ports-625x300-c.jpg">
+          <img src="images/Data/USB3_typeA_bottle2.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.howtogeek.com/wp-content/uploads/2014/01/650x434xusb-2.0-vs-usb-3.0-blue-port.jpg.pagespeed.gp+jp+jw+pj+js+rj+rp+rw+ri+cp+md.ic.Hw2qDXl-UA.jpg">
+        </div>
+        <p>Similar in sixe, shape, appearance to USB 2.0 Type A, though it has additional pins. Typically colored blue to differentiate from USB 2.0 Type A connections.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 3.0 Type A -->
+
+<!-- USB 3.0 Type B -->
+<span data-toggle="modal" data-target="#usb3_type-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB3_typeB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type B</button></span>
+<div id="usb3_type-b" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-30">USB 3.0 Type B</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB3_typeB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.datapro.net/images/usb_3_b.jpg">
+          <img src="images/Data/USB3_typeB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://hsto.org/getpro/habr/post_images/c40/af2/062/c40af20620352d5a35b1cadb413bc739.jpg">
+        </div>
+        <p>A boxy connection similar in appearance to USB 2.0 Type B, but not physically compatible with its preceding equivalent (unlike Type A). Therefore cables with a USB 3.0 Type B connector are not compatible with devices with a USB 2.0 Type B port; however devices with a USB 3.0 Type B port <b>will</b> accept USB 2.0 Type B cables. Usually colored blue.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 3.0 Type B -->
+
+<!-- USB 3.0 Micro B -->
+<span data-toggle="modal" data-target="#usb3_micro-b"><button type="button" class="btn btn-default" style="width:150px;"><img src="images/Data/USB3_microB_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Micro B</button></span>
+<div id="usb3_micro-b" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-30">USB 3.0 Micro B</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB3_microB_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/USB3SAUBX.C.jpg">
+          <img src="images/Data/USB3_microB_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="https://farm6.staticflickr.com/5590/14717534619_7bf547c241_o.jpg">
+        </div>
+        <p>A connection totally unique to USB 3.0 cables and devices, incompatible with previous USB devices.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 3.0 Micro B -->
+
+</div> <!-- end USB 3.0 well -->
+
+<!-- start USB 3.1 protocol cables -->
+<div class="well">
+  <h5>USB 3.1</h5>
+  <p>"SuperSpeed+"</p>
+  <p><b>Introduced: </b>2013</p>
+  <p><b>Max bit depth and rate: </b>10 Gb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- USB 3.1 Type C -->
+<span data-toggle="modal" data-target="#usb3-1_type-c"><button type="button" class="btn btn-default"><img src="images/Data/USB3-1_typeC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Type C</button></span>
+<div id="usb3-1_type-c" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-31">USB 3.1 Type C</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/USB3-1_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://cnet2.cbsistatic.com/img/JplrP5OaMw-Qjju0FM-E9SJEPIs=/570x0/2015/12/07/fcf70d65-4104-465e-b017-c5af7e122527/20151203-usb-type-c-001.jpg">
+          <img src="images/Data/USB3-1_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://liliputing.com/wp-content/uploads/2015/03/macbook-type-c2.jpg">
+        </div>
+        <p>A reversible, symmetrical design capable of carrying data at 10 Gbit/s (between two USB 3.1-compatible devices), power, and built-in support for DisplayPort video and four channels of audio. Increasingly found as a charging/data port for PC laptops and Apple laptops via the Thunderbolt protocol.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end USB 3.1 Type C -->
+
+</div> <!-- end USB 3.1 well -->
+
+</div> <!-- end USB well -->
+
+<!-- start FireWire protocol cables -->
+<div class="well">
+  <h4 id="firewire_data">FireWire</h4>
+  <p>Developed by Apple at roughly the same time as USB, for the similar purpose of consolidating connections and improving data transfer speeds. Unlike USB, FireWire does not require the use of a host controller (FireWire-compatible devices can communicate directly to each other without the use of a computer), but it was more costly to implement than USB and therefore never quite as popular. Sometimes referred to as i.Link (in Sony applications) and Lynx (Texas Instruments), as FireWire is technically just the Apple branding of the IEEE 1394 standard. Used for connections to external hard drives, as well as A/V component communication and control. Two major flavors of FireWire were introduced before Apple phased out development of the standard in favor of Thunderbolt. Ports usually represented by the symbol below.</p>
+  <img src="images/Data/firewire_logo.png" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/FireWire_Logo.svg/2000px-FireWire_Logo.svg.png" style="background-color:white; max-height:100px;">
+
+<!-- start FireWire 400 cables -->
+<div class="well">
+  <h5>FireWire 400</h5>
+  <p>"IEEE 1394a"</p>
+  <p><b>Introduced: </b>1995</p>
+  <p><b>Max bith depth and rate: </b>400 Mb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- FireWire 400 6-pin -->
+<span data-toggle="modal" data-target="#firewire400_6-pin"><button type="button" class="btn btn-default"><img src="images/firewire_6-pin.jpg" class="img-responsive" style="max-height:100px; width:auto;">6-pin</button></span>
+<div id="firewire400_6-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#6-pin">FireWire 400 6-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/firewire_6-pin.jpg">
+          <img src="images/Data/firewire_6-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://etc.usf.edu/te_mac/hardware/i/img_1744.jpg">
+        </div>
+        <p>Can carry DC power in addition to data; thus 6-pin connections are usually found on devices that can provide power, e.g. computers.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end FireWire 400 6-pin -->
+
+<!-- FireWire 400 4-pin -->
+<span data-toggle="modal" data-target="#firewire400_4-pin"><button type="button" class="btn btn-default"><img src="images/firewire_4-pin.jpg" class="img-responsive" style="max-height:100px; width:auto;">4-pin</button></span>
+<div id="firewire400_4-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#4-pin">FireWire 400 4-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/firewire_4-pin.jpg">
+          <img src="images/Data/firewire_4-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.jontrosky.com/images/firewire_4_pin_port.jpg">
+        </div>
+        <p>Can only carry data, no power, thus found on peripherals and devices with their own power supply, such as DV cameras, certain external hard drives.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end FireWire 400 4-pin -->
+
+</div> <!-- end FireWire 400 well -->
+
+<!-- start FireWire 800 cables -->
+<div class="well">
+  <h5>FireWire 800</h5>
+  <p>"IEEE 1394b"</p>
+  <p><b>Introduced: </b>2002</p>
+  <p><b>Max bith depth and rate: </b>800 Mb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- FireWire 800 9-pin -->
+<span data-toggle="modal" data-target="#firewire800_9-pin"><button type="button" class="btn btn-default"><img src="images/Data/firewire_9-pin_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">9-pin</button></span>
+<div id="firewire800_9-pin" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#9-pin">FireWire 800 9-pin</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/firewire_9-pin_cork.jpg">
+          <img src="images/Data/firewire_9-pin_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://cdn-image.realsimple.com/sites/default/files/styles/rs_main_image/public/image/images/0809/firewire-800-port_300.jpg?itok=UMxZPpBw">
+        </div>
+        <p>Commonly found on Apple computers. Can be adapted to older 6-pin and 4-pin connectors, but data transfer will be limited to the old 400 Mbit/s rate.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end FireWire 800 9-pin -->
+
+</div> <!-- end FireWire 800 well -->
+
+</div> <!-- end FireWire well -->
+
+<!-- start Thunderbolt protocol cables -->
+<div class="well">
+  <h4 id="thunderbolt">Thunderbolt</h4>
+  <p>Developed by Apple as a replacement for FireWire. Combines computer bus data transmission with the DisplayPort digital video interface, as well as DC power, all over one cable/connection. The first two major versions of Thunderbolt shared a physical connector and had compatible wiring/channels, but the introduction of Thunderbolt 3 has been marked by major shifts in physical interface. Ports usually labelled by the symbol below.</p>
+ <img src="images/Data/thunderbolt_logo.jpg" data-toggle="tooltip" data-placement="bottom" title="https://support.apple.com/library/content/dam/edam/applecare/images/en_US/macpro/thunderbolt_logo.png" style="max-height:100px;">
+
+<!-- start Thunderbolt 1 and 2 cables -->
+<div class="well">
+  <h5>Thunderbolt 1 and 2</h5>
+  <p><b>Introduced: </b>2011;2013</p>
+  <p><b>Max bit depth and rate: </b>10 Gb/s; 20 Gb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- Thunderbolt 1 and 2 Mini-DisplayPort -->
+<span data-toggle="modal" data-target="#thunderbolt_mini-displayport"><button type="button" class="btn btn-default"><img src="images/Data/thunderbolt_mini-displayport_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">Mini-DisplayPort</button></span>
+<div id="thunderbolt_mini-displayport" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#displayport">Thunderbolt 1 and 2 Mini-DisplayPort</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/thunderbolt_mini-displayport_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="https://sgcdn.startech.com/005329/media/products/gallery_large/TBOLTMMXMW.D.jpg">
+          <img src="images/Data/thunderbolt_mini-displayport_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://support.seagate.com/kbimg/004528-1.jpg">
+        </div>
+        <p>The Thunderbolt protocol was designed to be compatible with the Mini-DisplayPort connections already present since 2008 on many Apple computers. Saved Apple from a major redesign for several years.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Thunderbolt 1 and 2 Mini-DisplayPort -->
+
+</div> <!-- end Thunderbolt 1 and 2 -->
+
+<!-- start Thunderbolt 3 cables -->
+<div class="well">
+  <h5>Thunderbolt 3</h5>
+  <p><b>Introduced: </b>2015</p>
+  <p><b>Max bit depth and rate: </b>40 Gb/s</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- Thunderbolt 3 USB Type C -->
+<span data-toggle="modal" data-target="#thunderbolt3_usb_type-c"><button type="button" class="btn btn-default"><img src="images/Data/thunderbolt_typeC_cork.jpg" class="img-responsive" style="max-height:100px; width:auto;">USB Type C</button></span>
+<div id="thunderbolt3_usb_type-c" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="pinouts.md#usb-31">Thunderbolt 3 USB Type C</a></h3>
+        <div class="sample-image">
+          <img src="images/Data/thunderbolt_typeC_cork.jpg" data-toggle="tooltip" data-placement="bottom" title="http://www.flatpanelshd.com/pictures/thunderbolt3-1l.jpg">
+          <img src="images/Data/thunderbolt_typeC_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://blogs.intel.com/technology/files/2015/08/Lenovo-ports.jpg">
+        </div>
+        <p>Because of its capability for transferring data, digital video/audio and power all over the same connection, Apple adapted the USB Type C connector to its Thunderbolt protocol and has started using the connection as the single port on its latest MacBook Air products.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end Thunderbolt 3 USB Type C -->
+
+</div> <!-- end Thunderbolt 3 -->
+
+</div> <!-- end Thunderbolt well -->
+
+<!-- start HDBaseT protocol cables -->
+<div class="well">
+  <h4 id="hdbaset">HDBaseT</h4>
+  <p>A standard for the transmission of uncompressed HD video, audio, power, and/or networking and Ethernet connections.</p>
+  <p><b>Introduced: </b>2010</p>
+  <p><b>Max bit depth and rate: </b>10.2 Gbit/s (100 Mbit/s Ethernet)</p>
+  <p><b>Connectors and ports:</b></p>
+
+<!-- HDBaseT 8P8C -->
+<span data-toggle="modal" data-target="#hdbaset_8p8c"><button type="button" class="btn btn-default">8P8C/RJ-45</button></span>
+<div id="hdbaset_8p8c" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3>HDBaseT 8P8C/RJ-45</h3>
+        <p>A modular connector with 8 pins/conductors. Similar to but wider than the modular connectors used for phone lines.</p>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- end HDBaseT 8P8C -->
+
+</div> <!-- end HDBaseT well -->
+
+</div> <!-- end Serial Data well -->
+
+</div> <!-- end Data well -->
+
+<!-- start Power cables -->
+<div class="well">
+  <h2 id="power"><u>Power</u></h2>
+  <p>From Type A to Type N, the <a href="http://www.iec.ch/worldplugs/" target="_blank">IEC website</a> provides descriptions, images, and supporting countries to plugs and sockets used around the world.</p>
+</div> <!-- end Power well -->
 
 </div> <!-- end class="well col-md-8 col-md-offset-0" -->
+
 </div> <!-- end class="row" -->
 
 
@@ -2128,23 +2163,24 @@
 <!-- <span data-toggle="modal" data-target="#*****unique name*****"><button type="button" class="btn btn-default"><img src="****link to image in Github repo****" class="img-responsive" style="max-height:100px; width:auto;">**name of connector**</button></span>
 Change the above data-target field, the link to the corresponding connector image (in the Github repo "images" folder), the button text, and the below div ID
 <div id="*****unique name*****" class="modal fade" tabindex="-1" role="dialog">
-<div class="modal-dialog modal-lg">
-  <div class="modal-content">
-    <div class="well">
-      <h3><a href="***link to connector pinout in Github repo pinouts.md file***">*****Longer title(protocol + connector)*****</a></h3>
-      <div class="sample-image">
-        <img src="***link to cork connector image" data-toggle="tooltip" data-placement="bottom" title="***link to original image URL, if applicable***">
-        <img src="***link to bottle connector image" data-toggle="tooltip" data-placement="bottom" title="***link to original image URL, if applicable***">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="well">
+        <h3><a href="***link to connector pinout in Github repo pinouts.md file***">*****Longer title(protocol + connector)*****</a></h3>
+        <div class="sample-image">
+          <img src="***link to cork connector image" data-toggle="tooltip" data-placement="bottom" title="***link to original image URL, if applicable***">
+          <img src="***link to bottle connector image" data-toggle="tooltip" data-placement="bottom" title="***link to original image URL, if applicable***">
+        </div>
+        <p>*****description of connector context, equipment or scenarios where you would see it****</p>
+        <p>Audio: ***yes or no?***</p>
       </div>
-      <p>*****description of connector context, equipment or scenarios where you would see it****</p>
-      <p>Audio: ***yes or no?***</p>
     </div>
   </div>
-</div>
 </div> -->
 <!-- ends sample example -->
 
 
 </div> <!-- class="container" -->
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@
 <div class="modal-dialog modal-lg">
   <div class="modal-content">
     <div class="well">
-      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#scart">Component Y'P<sub>B</sub>P<sub>R</sub> SCART</a></h3>
+      <h3><a href="https://github.com/amiaopensource/cable-bible/blob/master/pinouts.md#scart">Component Y′P<sub>B</sub>P<sub>R</sub> SCART</a></h3>
       <div class="sample-image">
         <img src="images/SCART.jpg" data-toggle="tooltip" data-placement="bottom" title="https://upload.wikimedia.org/wikipedia/commons/1/11/SCART_20050724_002.jpg">
         <img src="images/Video/scart_bottle.jpg" data-toggle="tooltip" data-placement="bottom" title="http://img.publish.it168.com/2005/1201/images/526200.jpg">

--- a/index.html
+++ b/index.html
@@ -42,54 +42,54 @@
   <div class="well" id="table_of_contents">
     <h2>What kind of cable are you looking for?</h2>
     <ol type="I">
-      <li><a href="#video">Video</a></li>
+      <li><a href="#video">Video</a>
       <ol type="A">
-      <li><a href="#analog_video">Analog Video</a></li>
+      <li><a href="#analog_video">Analog Video</a>
         <ol type="1">
         <li><a href="#composite">Composite</a></li>
         <li><a href="#component_ypbpr">Component Y′P<sub>B</sub>P<sub>R</sub></a></li>
         <li><a href="#s-video">S-Video</a></li>
         <li><a href="#rgbs">RGBS</a></li>
         <li><a href="#rgbvh">RGBVH</a></li>
-        </ol>
-      <li><a href="#digital_video">Digital Video</a></li>
+        </ol></li>
+      <li><a href="#digital_video">Digital Video</a>
         <ol type="1">
         <li><a href="#sdi">SDI</a></li>
         <li><a href="#firewire_video">FireWire (IEEE 1394)</a></li>
         <li><a href="#dvi">DVI</a></li>
         <li><a href="#displayport">DisplayPort</a></li>
         <li><a href="#hdmi">HDMI</a></li>
-        </ol>
-      <li><a href="#integrated_video">Integrated Video</a></li>
+        </ol></li>
+      <li><a href="#integrated_video">Integrated Video</a>
         <ol type="1">
         <li><a href="#dvi-i">DVI-I</a></li>
-        </ol>
-      </ol>
-    <li><a href="#audio">Audio</a></li>
+        </ol></li>
+      </ol></li>
+    <li><a href="#audio">Audio</a>
       <ol type="A">
-      <li><a href="#analog_audio">Analog Audio</a></li>
+      <li><a href="#analog_audio">Analog Audio</a>
         <ol type="1">
         <li><a href="#balanced_analog">Balanced</a></li>
         <li><a href="#unbalanced_analog">Unbalanced</a></li>
-        </ol>
-      <li><a href="#digital_audio">Digital Audio</a></li>
+        </ol></li>
+      <li><a href="#digital_audio">Digital Audio</a>
         <ol type="1">
         <li><a href="#aes-3">AES-3 (AES-EBU)</a></li>
         <li><a href="#spdif">S/PDIF</a></li>
         <li><a href="#midi">MIDI</a></li>
         <li><a href="#tdif">TDIF</a></li>
         <li><a href="#adat">ADAT</a></li>
-        </ol>
-      </ol>
-    <li><a href="#data">Data</a></li>
+        </ol></li>
+      </ol></li>
+    <li><a href="#data">Data</a>
       <ol type="A">
-      <li><a href="#parallel_data">Parallel Data</a></li>
+      <li><a href="#parallel_data">Parallel Data</a>
         <ol type="1">
         <li><a href="#pata">PATA</a></li>
         <li><a href="#parallel_scsi">Parellel SCSI</a></li>
         <li><a href="#parallel_port">IEEE 1284 "Parallel Port"</a></li>
-        </ol>
-      <li><a href="#serial_data">Serial Data</a></li>
+        </ol></li>
+      <li><a href="#serial_data">Serial Data</a>
         <ol type="1">
         <li><a href="#rs-232">RS-232 "Serial Port"</a></li>
         <li><a href="#rs-422">RS-422</a></li>
@@ -101,10 +101,10 @@
         <li><a href="#firewire_data">FireWire</a></li>
         <li><a href="#thunderbolt">ThunderBolt</a></li>
         <li><a href="#hdbaset">HDBaseT</a></li>
-        </ol>
-      </ol>
+        </ol></li>
+      </ol></li>
     <li><a href="#power">Power</a></li>
-  </ol>
+    </ol>
   </div>
 
   <!-- start Video cables -->


### PR DESCRIPTION
- unify capitalisation in title
- use prime not the not-typographic apostrophe in Y'PbPr
- use `″` instead of `"` for inches
- try to unify use of period
- unify e.g. `'90s` > `1990s`
- it’s easier to read with space before and after = (and non-breaking spaces avoid stupid rendering)
- little typos

**Caveat:** The use of `<ol>` breaks HTML syntax. I didn’t correct this. May be resolved together with https://github.com/amiaopensource/cable-bible/issues/20.

**Update:** done at https://github.com/amiaopensource/cable-bible/pull/19/commits/53fc0d64f3c65248480affc58ac2e2490819604d