### PR TITLE
script to open cable-bible via CLI/homebrew

### DIFF
--- a/cable-bible
+++ b/cable-bible
@@ -1,0 +1,20 @@
+#!/usr/bin/env vash
+
+if [[ $OSTYPE = darwin* ]] ; then
+  if [ -d /usr/local/Cellar/cable-bible ] ; then
+      cablebible_path=$(find /usr/local/Cellar/cable-bible -iname 'index.html' | sort -M | tail -n1)
+  fi
+  if [ -z "${cablebible_path}" ] ; then
+    cablebible_path='https://amiaopensource.github.io/cable-bible'
+  fi
+  open "${cablebible_path}"
+
+elif [[ $OSTYPE = linux-gnu ]] ; then
+  if [ -d ~/.linuxbrew/Cellar/cable-bible ] ; then
+    cablebible_path=$(find ~/.linuxbrew/Cellar/cable-bible -iname 'index.html' | sort -M | tail -n1)
+  fi
+  if [ -z "${cablebible_path}" ] ; then
+    cablebible_path='https://amiaopensource.github.io/cable-bible'
+  fi
+  xdg-open "${cablebible_path}"
+fi

--- a/cable-bible
+++ b/cable-bible
@@ -1,4 +1,4 @@
-#!/usr/bin/env vash
+#!/usr/bin/env bash
 
 if [[ $OSTYPE = darwin* ]] ; then
   if [ -d /usr/local/Cellar/cable-bible ] ; then


### PR DESCRIPTION
used [script](https://github.com/amiaopensource/ffmprovisr/blob/gh-pages/scripts/ffmprovisr) by @privatezero for local executable install of ffmprovisr via homebrew to replicate the same functionality for cable-bible repo; addresses #22 

have tested on both Ubuntu 16.04 (linuxbrew) and macOS

needs cable-bible.rb to add to homebrew-amiaos